### PR TITLE
chore(hooks): add bun install SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,7 +73,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun install"
+            "command": "bun install --ignore-scripts"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds a `SessionStart` hook with `startup` matcher to `.claude/settings.json`
- Runs `bun install` automatically when a new Claude Code session starts
- Ensures dependencies are always fresh after branch switches or pulling changes
- Does **not** run on resume/clear/compact events (only `startup`)

## Test plan

- [ ] Start a new Claude Code session and verify `bun install` runs automatically in the session start output
- [ ] Resume an existing session and confirm `bun install` does **not** run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically run `bun install --ignore-scripts` when starting a new Claude Code session by adding a `SessionStart` hook with the `startup` matcher in `.claude/settings.json`. This keeps dependencies fresh after branch switches or pulls, skips post-install scripts for safety, and does not run on resume/clear/compact.

<sup>Written for commit a2d93ae8ad2054c8ce09ceed1e47b2e077f19a5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

