### PR TITLE
chore: update project config and ignore rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,8 @@
     "code-review@pleaseai": true,
     "claude-md-management@pleaseai": true,
     "gatekeeper@pleaseai": true,
+    "fetch@pleaseai": true,
+    "markitdown@pleaseai": true,
     "typescript-lsp@code-intelligence": true,
     "eslint-lsp@code-intelligence": true,
     "ralph-loop@claude-plugins-official": true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 .turbo/
 bun.lock
 *.tsbuildinfo
+.claude/settings.local.json
+/.claude/worktrees/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/symphony" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
## Summary

- Add `fetch@pleaseai` and `markitdown@pleaseai` plugins to Claude Code settings
- Add `.claude/settings.local.json` and `/.claude/worktrees/` to `.gitignore`
- Add `vendor/symphony` VCS mapping in IDE config (`.idea/vcs.xml`)
- Remove redundant XML declaration from `.idea/misc.xml`

## Test plan

- [ ] Verify Claude Code loads fetch and markitdown plugins correctly
- [ ] Confirm local settings and worktree directories are excluded from git tracking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `fetch@pleaseai` and `markitdown@pleaseai` in Claude Code to improve local tooling. Clean up project config: add VCS mapping for `vendor/symphony`, ignore `.claude/settings.local.json` and `/.claude/worktrees/`, and remove the redundant XML header in `.idea/misc.xml`.

<sup>Written for commit 6e138e5c31b5cd6d38ccb6459c74ab00e5714704. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

