### PR TITLE
ci: Set package ecosystem to 'bun' in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,14 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable `Dependabot` for `bun` at `/` with weekly checks, grouping minor/patch updates for dev and prod deps to reduce PR noise.

<sup>Written for commit a5f8acf7db9fc2b273b7c1eb36578ac494fc1357. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

