### PR TITLE
chore(release): prevent version bump to 1.0.0 in pre-major phase

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,8 @@
       "release-type": "node",
       "package-name": "@pleaseai/work",
       "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "private": true
     }
   }


### PR DESCRIPTION
## Summary

- Add `bump-minor-pre-major: true` so feature commits bump the minor version (e.g. 0.2.0 → 0.3.0) instead of major
- Add `bump-patch-for-minor-pre-major: true` so fix commits bump the patch version (e.g. 0.2.0 → 0.2.1) instead of minor
- Prevents release-please from promoting the package to 1.0.0 while the project is still in the 0.x pre-major phase

## Test plan

- [ ] Verify release-please dry-run produces 0.x version bumps for `feat:` and `fix:` commits
- [ ] Confirm no unintended 1.0.0 release is triggered by the next automated release PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `release-please` config to add `bump-minor-pre-major` and `bump-patch-for-minor-pre-major`, so `feat:` bumps minor and `fix:` bumps patch while in 0.x. Prevents promoting `@pleaseai/work` to 1.0.0 until we leave the pre-major phase.

<sup>Written for commit b94579aae1c2e659514b49eee238bbbd646fd5f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

