### PR TITLE
build(release): promote bump flags to root config level

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "packages": {
     "apps/work-please": {
       "release-type": "node",
       "package-name": "@pleaseai/work",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "private": true
     }
   }


### PR DESCRIPTION
## Summary

- Move `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` from package-level (`apps/work-please`) to root level in `release-please-config.json`
- Root-level settings serve as global defaults, eliminating per-package duplication

## Test plan

- [ ] Verify release-please picks up root-level bump flags on next release run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` to the root of `release-please-config.json` so they apply globally and remove per-package duplication. These root-level flags now act as defaults for all packages.

<sup>Written for commit fbdf27dc88a1834424767df7e89c3a4844754472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

