### PR TITLE
build(deps): update lockfile with eslint dev dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,9 +23,12 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@antfu/eslint-config": "^7.7.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.4.0",
         "bun-types": "^1.3.10",
+        "eslint": "^10.0.3",
+        "typescript": "^5.7.0",
       },
     },
   },


### PR DESCRIPTION
## Summary

- Updates `bun.lock` to include `@antfu/eslint-config ^7.7.0`, `eslint ^10.0.3`, and `typescript ^5.7.0` as dev dependencies for the `apps/work-please` workspace
- This lockfile update was leftover from PR #15 (build(work-please): add app-level eslint config) and needs to be committed separately

## Test plan

- [ ] Verify `bun install` completes without errors
- [ ] Verify `bun run lint:app` runs successfully with the updated lockfile

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `bun.lock` to add dev dependencies for `apps/work-please`: `@antfu/eslint-config` ^7.7.0, `eslint` ^10.0.3, and `typescript` ^5.7.0. Aligns the lockfile with the ESLint config added in PR #15 so installs and lint scripts run cleanly.

<sup>Written for commit 50eacf38f5339db3d27ccffbbb189bf718385f60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

