### PR TITLE
chore(settings): enable ast-grep plugin from pleaseai marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,8 @@
     "markitdown@pleaseai": true,
     "typescript-lsp@code-intelligence": true,
     "eslint-lsp@code-intelligence": true,
-    "ralph-loop@claude-plugins-official": true
+    "ralph-loop@claude-plugins-official": true,
+    "ast-grep@pleaseai": true
   },
   "extraKnownMarketplaces": {
     "passionfactory": {


### PR DESCRIPTION
## Summary

- Adds `ast-grep@pleaseai` to the allowed plugins list in `.claude/settings.json`
- Enables AST-based structural code search using the ast-grep plugin for language-aware queries

## Test plan

- [ ] Verify Claude Code loads the ast-grep plugin without errors
- [ ] Confirm `ast-grep` commands work for code search tasks in the workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the `ast-grep@pleaseai` plugin in `.claude/settings.json` to provide AST-based, language-aware structural code search in Claude Code. This allows running `ast-grep` queries across the workspace.

<sup>Written for commit 0c64b61905c4040d84a8e19f3bad0c10e1325fc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

