### PR TITLE
build(eslint): set root config type to app to fix ci sort-imports

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,7 +1,7 @@
 import antfu from '@antfu/eslint-config'
 
 export default antfu({
-  type: 'lib',
+  type: 'app',
   typescript: true,
   stylistic: {
     indent: 2,


### PR DESCRIPTION
## Summary

- Root `eslint.config.ts`의 `type: 'lib'`을 `type: 'app'`으로 변경

## Problem

CI에서 `perfectionist/sort-imports` 규칙 오류 발생:
```
Expected "bun:test" to come before "node:path"
```

`type: 'lib'` 설정 시 `bun:test`가 builtin으로 분류되어 `node:*` 앞에 와야 했지만, `apps/work-please`의 앱 레벨 config는 이미 `type: 'app'`을 사용하고 있어 로컬에서는 문제없었습니다.

## Fix

루트 config를 `type: 'app'`으로 통일하여 로컬과 CI에서 일관된 동작 보장:
- `type: 'app'`: `bun:test` → external (node:* 뒤)
- `type: 'lib'`: `bun:test` → builtin (node:* 앞)

## Test plan

- [ ] CI lint 통과 확인

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set root ESLint config to `type: 'app'` to align with app-level config and fix CI failures from `perfectionist/sort-imports`.

- **Bug Fixes**
  - `bun:test` is now treated as external, so it comes after `node:*` imports.
  - Ensures consistent lint behavior locally and in CI.

<sup>Written for commit 3c9967930351aae3ba317a5969e246634e3ce2fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

