### PR TITLE
fix(init): use repositoryOwner to resolve both org and user logins

### DIFF
--- a/apps/work-please/src/init.test.ts
+++ b/apps/work-please/src/init.test.ts
@@ -122,10 +122,10 @@ describe('generateWorkflow', () => {
 // ---------------------------------------------------------------------------
 
 describe('resolveOwnerId', () => {
-  it('returns the organization id when org is found', async () => {
+  it('returns the owner id for an organization login', async () => {
     const origFetch = globalThis.fetch
     globalThis.fetch = mock(async () =>
-      mockResponse(true, { data: { organization: { id: 'O_org123' }, user: null } }),
+      mockResponse(true, { data: { repositoryOwner: { id: 'O_org123' } } }),
     ) as unknown as typeof fetch
     try {
       const result = await resolveOwnerId('tok', 'myorg', 'http://localhost')
@@ -134,10 +134,10 @@ describe('resolveOwnerId', () => {
     finally { globalThis.fetch = origFetch }
   })
 
-  it('falls back to user id when org is null', async () => {
+  it('returns the owner id for a user login', async () => {
     const origFetch = globalThis.fetch
     globalThis.fetch = mock(async () =>
-      mockResponse(true, { data: { organization: null, user: { id: 'U_user456' } } }),
+      mockResponse(true, { data: { repositoryOwner: { id: 'U_user456' } } }),
     ) as unknown as typeof fetch
     try {
       const result = await resolveOwnerId('tok', 'myuser', 'http://localhost')
@@ -146,10 +146,10 @@ describe('resolveOwnerId', () => {
     finally { globalThis.fetch = origFetch }
   })
 
-  it('returns init_owner_not_found when both org and user are null', async () => {
+  it('returns init_owner_not_found when repositoryOwner is null', async () => {
     const origFetch = globalThis.fetch
     globalThis.fetch = mock(async () =>
-      mockResponse(true, { data: { organization: null, user: null } }),
+      mockResponse(true, { data: { repositoryOwner: null } }),
     ) as unknown as typeof fetch
     try {
       const result = await resolveOwnerId('tok', 'nobody', 'http://localhost')
@@ -160,7 +160,7 @@ describe('resolveOwnerId', () => {
     finally { globalThis.fetch = origFetch }
   })
 
-  it('returns init_owner_not_found when data has no id fields', async () => {
+  it('returns init_owner_not_found when data has no repositoryOwner field', async () => {
     const origFetch = globalThis.fetch
     globalThis.fetch = mock(async () =>
       mockResponse(true, { data: {} }),
@@ -333,7 +333,7 @@ describe('initProject', () => {
     globalThis.fetch = mock(async () => {
       callCount++
       if (callCount === 1) {
-        return mockResponse(true, { data: { organization: { id: 'O_org1' }, user: null } })
+        return mockResponse(true, { data: { repositoryOwner: { id: 'O_org1' } } })
       }
       return mockResponse(true, { data: { createProjectV2: { projectV2: { id: 'PVT_1', number: 3 } } } })
     }) as unknown as typeof fetch
@@ -404,7 +404,7 @@ describe('initProject', () => {
     globalThis.fetch = mock(async () => {
       callCount++
       if (callCount === 1)
-        return mockResponse(true, { data: { organization: { id: 'O_org1' }, user: null } })
+        return mockResponse(true, { data: { repositoryOwner: { id: 'O_org1' } } })
       return mockResponse(false, { message: 'Forbidden' }, 403)
     }) as unknown as typeof fetch
     try {
@@ -430,7 +430,7 @@ describe('initProject', () => {
     globalThis.fetch = mock(async () => {
       callCount++
       if (callCount === 1)
-        return mockResponse(true, { data: { organization: { id: 'O_org1' }, user: null } })
+        return mockResponse(true, { data: { repositoryOwner: { id: 'O_org1' } } })
       return mockResponse(true, { data: { createProjectV2: { projectV2: { id: 'PVT_1', number: 7 } } } })
     }) as unknown as typeof fetch
     try {

--- a/apps/work-please/src/init.ts
+++ b/apps/work-please/src/init.ts
@@ -61,8 +61,7 @@ async function runGraphql(
 
 const RESOLVE_OWNER_QUERY = `
   query($login: String!) {
-    organization(login: $login) { id }
-    user(login: $login) { id }
+    repositoryOwner(login: $login) { id }
   }
 `
 
@@ -75,8 +74,8 @@ export async function resolveOwnerId(
   if ('code' in result)
     return result
 
-  const data = result.data as { organization?: { id?: string }, user?: { id?: string } }
-  const id = data.organization?.id ?? data.user?.id
+  const data = result.data as { repositoryOwner?: { id?: string } }
+  const id = data.repositoryOwner?.id
   if (!id) {
     return { code: 'init_owner_not_found', owner }
   }


### PR DESCRIPTION
## Summary

- Replace dual `organization` + `user` GraphQL query with the `repositoryOwner` field
- `repositoryOwner` resolves both organizations and users in a single query without errors
- Fixes `init_graphql_errors` when using an organization login (e.g. `--owner chatbot-pf`)

## Root Cause

The previous query queried both `organization(login)` and `user(login)` simultaneously. When the login belongs to an org, GitHub returns a `NOT_FOUND` error for the `user` field alongside the valid org data. `@octokit/graphql` throws `GraphqlResponseError` in this case, which the code mapped to `init_graphql_errors`.

## Test Plan

- [x] `resolveOwnerId` — updated tests for org login, user login, null owner, missing field
- [x] `initProject` — updated mock responses to use `repositoryOwner` shape
- [x] All 287 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `init` to GitHub GraphQL `repositoryOwner(login)` to resolve both org and user IDs in one request. Fixes `init_graphql_errors` for org logins by avoiding partial-data errors.

- **Bug Fixes**
  - Replaced `organization(login)` + `user(login)` queries with `repositoryOwner(login)` to prevent `GraphqlResponseError` from `@octokit/graphql`.
  - Updated `resolveOwnerId` logic and tests (including `initProject`) to the new response shape.

<sup>Written for commit eddd838022fb9475532cf0941ed457feee35eeca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

