### PR TITLE
feat(init): configure Status field with In Review and Cancelled options

### DIFF
--- a/apps/work-please/src/init.test.ts
+++ b/apps/work-please/src/init.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, rmSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
+  configureStatusField,
   createProject,
   generateWorkflow,
   initProject,
@@ -114,6 +115,67 @@ describe('generateWorkflow', () => {
     const a = generateWorkflow('myorg', 1)
     const b = generateWorkflow('myorg', 99)
     expect(a).not.toBe(b)
+  })
+
+  it('includes "In Review" instruction in PR step', () => {
+    const content = generateWorkflow('myorg', 42)
+    expect(content).toContain('In Review')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// configureStatusField
+// ---------------------------------------------------------------------------
+
+describe('configureStatusField', () => {
+  it('returns true on success', async () => {
+    const origFetch = globalThis.fetch
+    let callCount = 0
+    globalThis.fetch = mock(async () => {
+      callCount++
+      if (callCount === 1) {
+        return mockResponse(true, { data: { node: { field: { id: 'FIELD_1' } } } })
+      }
+      return mockResponse(true, { data: { updateProjectV2Field: { projectV2Field: { id: 'FIELD_1' } } } })
+    }) as unknown as typeof fetch
+    try {
+      const result = await configureStatusField('tok', 'PVT_1', 'http://localhost')
+      expect(result).toBe(true)
+    }
+    finally { globalThis.fetch = origFetch }
+  })
+
+  it('returns error when status field not found', async () => {
+    const origFetch = globalThis.fetch
+    globalThis.fetch = mock(async () =>
+      mockResponse(true, { data: { node: { field: null } } }),
+    ) as unknown as typeof fetch
+    try {
+      const result = await configureStatusField('tok', 'PVT_1', 'http://localhost')
+      expect(isInitError(result)).toBe(true)
+      if (isInitError(result))
+        expect(result.code).toBe('init_create_failed')
+    }
+    finally { globalThis.fetch = origFetch }
+  })
+
+  it('returns error when update mutation fails with GraphQL errors', async () => {
+    const origFetch = globalThis.fetch
+    let callCount = 0
+    globalThis.fetch = mock(async () => {
+      callCount++
+      if (callCount === 1) {
+        return mockResponse(true, { data: { node: { field: { id: 'FIELD_1' } } } })
+      }
+      return mockResponse(true, { errors: [{ message: 'Cannot update field' }] })
+    }) as unknown as typeof fetch
+    try {
+      const result = await configureStatusField('tok', 'PVT_1', 'http://localhost')
+      expect(isInitError(result)).toBe(true)
+      if (isInitError(result))
+        expect(result.code).toBe('init_graphql_errors')
+    }
+    finally { globalThis.fetch = origFetch }
   })
 })
 
@@ -443,6 +505,66 @@ describe('initProject', () => {
       expect(isInitError(result)).toBe(false)
       if (!isInitError(result))
         expect(result.workflowPath).toBe(resolve(tmpDir, 'WORKFLOW.md'))
+    }
+    finally { globalThis.fetch = origFetch }
+  })
+
+  it('returns statusConfigured: true when all 4 API calls succeed', async () => {
+    const origFetch = globalThis.fetch
+    let callCount = 0
+    globalThis.fetch = mock(async () => {
+      callCount++
+      if (callCount === 1)
+        return mockResponse(true, { data: { repositoryOwner: { id: 'O_org1' } } })
+      if (callCount === 2)
+        return mockResponse(true, { data: { createProjectV2: { projectV2: { id: 'PVT_1', number: 3 } } } })
+      if (callCount === 3)
+        return mockResponse(true, { data: { node: { field: { id: 'FIELD_1' } } } })
+      return mockResponse(true, { data: { updateProjectV2Field: { projectV2Field: { id: 'FIELD_1' } } } })
+    }) as unknown as typeof fetch
+    try {
+      const result = await initProject(
+        { owner: 'myorg', title: 'My Board', token: 'tok' },
+        'http://localhost',
+        tmpDir,
+      )
+
+      expect(isInitError(result)).toBe(false)
+      if (!isInitError(result)) {
+        expect(result.statusConfigured).toBe(true)
+        expect(result.projectNumber).toBe(3)
+        expect(result.projectId).toBe('PVT_1')
+      }
+    }
+    finally { globalThis.fetch = origFetch }
+  })
+
+  it('returns statusConfigured: false when status configuration fails (non-fatal)', async () => {
+    const origFetch = globalThis.fetch
+    let callCount = 0
+    globalThis.fetch = mock(async () => {
+      callCount++
+      if (callCount === 1)
+        return mockResponse(true, { data: { repositoryOwner: { id: 'O_org1' } } })
+      if (callCount === 2)
+        return mockResponse(true, { data: { createProjectV2: { projectV2: { id: 'PVT_1', number: 3 } } } })
+      return mockResponse(true, { data: { node: { field: null } } })
+    }) as unknown as typeof fetch
+    try {
+      const result = await initProject(
+        { owner: 'myorg', title: 'My Board', token: 'tok' },
+        'http://localhost',
+        tmpDir,
+      )
+
+      expect(isInitError(result)).toBe(false)
+      if (!isInitError(result)) {
+        expect(result.statusConfigured).toBe(false)
+        expect(result.projectNumber).toBe(3)
+      }
+
+      const written = readFileSync(join(tmpDir, 'WORKFLOW.md'), 'utf-8')
+      expect(written).toContain('owner: "myorg"')
     }
     finally { globalThis.fetch = origFetch }
   })

--- a/apps/work-please/src/init.ts
+++ b/apps/work-please/src/init.ts
@@ -18,6 +18,7 @@ export interface InitResult {
   projectNumber: number
   owner: string
   workflowPath: string
+  statusConfigured: boolean
 }
 
 export type InitError
@@ -112,6 +113,73 @@ export async function createProject(
   return { projectId: project.id, projectNumber: project.number }
 }
 
+const GET_STATUS_FIELD_QUERY = `
+  query($projectId: ID!) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        field(name: "Status") {
+          ... on ProjectV2SingleSelectField { id }
+        }
+      }
+    }
+  }
+`
+
+const UPDATE_STATUS_FIELD_MUTATION = `
+  mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+    updateProjectV2Field(input: {
+      fieldId: $fieldId
+      singleSelectOptions: $options
+    }) {
+      projectV2Field { ... on ProjectV2SingleSelectField { id } }
+    }
+  }
+`
+
+const STATUS_OPTIONS = [
+  { name: 'Todo', description: 'Not started', color: 'GRAY' },
+  { name: 'In Progress', description: 'Currently being worked on', color: 'YELLOW' },
+  { name: 'In Review', description: 'PR created, awaiting human review', color: 'BLUE' },
+  { name: 'Done', description: 'Completed', color: 'GREEN' },
+  { name: 'Cancelled', description: 'Will not be done', color: 'RED' },
+]
+
+export async function getStatusFieldId(
+  token: string,
+  projectId: string,
+  endpoint: string = GITHUB_API_ENDPOINT,
+): Promise<string | InitError> {
+  const result = await runGraphql(endpoint, token, GET_STATUS_FIELD_QUERY, { projectId })
+  if ('code' in result)
+    return result
+
+  const data = result.data as { node?: { field?: { id?: string } } }
+  const id = data.node?.field?.id
+  if (!id) {
+    return { code: 'init_create_failed', cause: 'Status field not found in project' }
+  }
+  return id
+}
+
+export async function configureStatusField(
+  token: string,
+  projectId: string,
+  endpoint: string = GITHUB_API_ENDPOINT,
+): Promise<true | InitError> {
+  const fieldIdResult = await getStatusFieldId(token, projectId, endpoint)
+  if (isInitError(fieldIdResult))
+    return fieldIdResult
+
+  const result = await runGraphql(endpoint, token, UPDATE_STATUS_FIELD_MUTATION, {
+    fieldId: fieldIdResult,
+    options: STATUS_OPTIONS,
+  })
+  if ('code' in result)
+    return result
+
+  return true
+}
+
 export function generateWorkflow(owner: string, projectNumber: number): string {
   return `---
 tracker:
@@ -197,7 +265,7 @@ You are operating in an unattended session. Follow these rules:
 3. **Implement the changes** — follow the repository conventions in \`CLAUDE.md\` if present.
 4. **Run tests and lint** — ensure all checks pass before committing.
 5. **Commit using conventional format** — e.g. \`feat(scope): add new capability\`.
-6. **Push and open a PR** — create or update a pull request linked to the issue URL.
+6. **Push and open a PR** — create or update a pull request linked to the issue URL. After the PR is created, move the issue status to \`In Review\`.
 7. **Operate autonomously** — never ask a human for follow-up actions. Complete the task end-to-end.
 8. **Blocked?** — if blocked by missing auth, permissions, or secrets that cannot be resolved in-session, document the blocker clearly and stop. Do not loop indefinitely.
 `
@@ -222,6 +290,9 @@ export async function initProject(
   if (isInitError(projectResult))
     return projectResult
 
+  const statusResult = await configureStatusField(options.token, projectResult.projectId, endpoint)
+  const statusConfigured = statusResult === true
+
   const workflowContent = generateWorkflow(options.owner, projectResult.projectNumber)
   writeFileSync(workflowPath, workflowContent, 'utf-8')
 
@@ -230,6 +301,7 @@ export async function initProject(
     projectNumber: projectResult.projectNumber,
     owner: options.owner,
     workflowPath,
+    statusConfigured,
   }
 }
 
@@ -277,5 +349,10 @@ export async function runInit(options: {
 
   console.warn(`[work-please] created GitHub Projects v2 board: #${result.projectNumber}`)
   console.warn(`[work-please] generated ${result.workflowPath}`)
-  console.warn('[work-please] Note: add a "Cancelled" status to your project manually via GitHub UI if needed')
+  if (result.statusConfigured) {
+    console.warn('[work-please] configured Status field: Todo, In Progress, In Review, Done, Cancelled')
+  }
+  else {
+    console.warn('[work-please] warning: could not configure Status field — add "In Review" and "Cancelled" statuses manually')
+  }
 }


### PR DESCRIPTION
## Summary

- Add `configureStatusField` function that queries the project's Status field ID then updates all options in a single `updateProjectV2Field` mutation
- Five Status options configured: **Todo** (GRAY), **In Progress** (YELLOW), **In Review** (BLUE), **Done** (GREEN), **Cancelled** (RED)
- `initProject` calls `configureStatusField` after project creation — failure is **non-fatal** (`statusConfigured: false` returned, WORKFLOW.md still written)
- `runInit` prints a success message listing all 5 options, or a warning to add them manually on failure
- `generateWorkflow` step 6 now instructs the agent to move the issue to `In Review` after opening a PR

## Changes

- `apps/work-please/src/init.ts`
  - `InitResult.statusConfigured: boolean` added
  - `getStatusFieldId` and `configureStatusField` exported functions added
  - `GET_STATUS_FIELD_QUERY` and `UPDATE_STATUS_FIELD_MUTATION` GraphQL constants added
  - `initProject` calls `configureStatusField` (non-fatal)
  - `runInit` conditional status message (removes old "add Cancelled manually" warn)
  - `generateWorkflow` step 6 updated with `In Review` handoff instruction
- `apps/work-please/src/init.test.ts`
  - Import `configureStatusField`
  - `generateWorkflow`: new test for "In Review" text
  - New `configureStatusField` suite: success, field not found, update GraphQL error
  - New `initProject` tests: `statusConfigured: true` (4 API calls) and `statusConfigured: false` (non-fatal)

## Test plan

- [x] All 293 tests pass (`bun run test:app`)
- [x] Type check passes (`bun run check:app`)
- [x] Pre-existing lint error in `WORKFLOW.md` (untracked, not in this PR) confirmed pre-existing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically configures the project's Status field during init with five options (including In Review and Cancelled) and updates the workflow to move issues to In Review after opening a PR. Failures are non-fatal and surfaced to the user.

- **New Features**
  - Added `configureStatusField` to fetch the Status field ID and overwrite all options in one update.
  - Five options set: Todo (GRAY), In Progress (YELLOW), In Review (BLUE), Done (GREEN), Cancelled (RED).
  - `initProject` now returns `statusConfigured`; still writes `WORKFLOW.md` on failure.
  - `runInit` prints a success list or a warning to add In Review/Cancelled manually.
  - `generateWorkflow` step 6 instructs moving the issue to In Review after the PR is created.

<sup>Written for commit 734c9dc6d4102095544624fb22279f0f5fbe76b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

