### PR TITLE
refactor(test): use direct await over resolves assertion style

### DIFF
--- a/apps/work-please/src/workspace.test.ts
+++ b/apps/work-please/src/workspace.test.ts
@@ -269,14 +269,14 @@ describe('runAfterRunHook', () => {
 
   it('does nothing when no after_run hook configured', async () => {
     const config = makeConfig(tmpRoot)
-    await expect(runAfterRunHook(config, tmpRoot)).resolves.toBeUndefined()
+    expect(await runAfterRunHook(config, tmpRoot)).toBeUndefined()
   })
 
   it('runs after_run hook and logs (does not throw) on failure', async () => {
     const config = makeConfig(tmpRoot, {
       hooks: { after_run: 'exit 2' },
     })
-    await expect(runAfterRunHook(config, tmpRoot)).resolves.toBeUndefined()
+    expect(await runAfterRunHook(config, tmpRoot)).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

- Replace `await expect(fn()).resolves.toBeUndefined()` with `expect(await fn()).toBeUndefined()` in `workspace.test.ts`
- Cleaner and more idiomatic async assertion style in Bun/Jest test runner

## Test plan

- [ ] Existing tests pass: `bun run test:app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `workspace.test.ts` to replace `await expect(...).resolves.toBeUndefined()` with `expect(await ...).toBeUndefined()` for clearer async assertions. No behavior change; improves readability and aligns with our test style.

<sup>Written for commit 177951e42dbb32c787ac35b2ab227d830d8f4592. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

