### PR TITLE
chore: add version field to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "work-please",
   "private": true,
+  "version": "0.0.0",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
## Summary

- Add `"version": "0.0.0"` to the root `package.json` to satisfy tooling that expects a version field in the workspace root manifest.

## Test plan

- [ ] Verify `bun install` still completes cleanly with no changes
- [ ] Confirm no workspace scripts are broken

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add version "0.0.0" to the root `package.json` to satisfy tools that require a version in the workspace root. No impact on builds or publishing since the root is `private`.

<sup>Written for commit 1288b8dfc5548c1e3bed76ed66ed23758b5ec386. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

