### PR TITLE
fix(release): remove root package from release-please to prevent 1.0.0 bump

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,3 @@
 {
-  "apps/work-please": "0.0.0",
-  ".": "0.0.0"
+  "apps/work-please": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "workplease",
+  "name": "work-please",
   "private": true,
   "version": "0.0.0",
   "workspaces": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,16 +3,11 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "packages": {
-    ".": {
-      "release-type": "node",
-      "package-name": "work-please",
-      "changelog-path": "CHANGELOG.md",
-      "private": true
-    },
     "apps/work-please": {
       "release-type": "node",
       "package-name": "@pleaseai/work",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "initial-version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Remove `"."` (root) package from `release-please-config.json` and `.release-please-manifest.json`
  — it is `private: true` and never published to npm, so tracking it serves no purpose
- Add `initial-version: "0.1.0"` to `apps/work-please` to prevent the same `0.0.0 → 1.0.0` jump on first release
- Fix root `package.json` `name` field from `workplease` to `work-please` for consistency

## Problem

Release Please was generating a `0.0.0 → 1.0.0` version bump PR for the root package despite `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true` being set. This is because Release Please treats `0.0.0` as a special "never released" sentinel and does not apply the bump flags on the initial release computation.

The same issue would affect `apps/work-please` on its first release, so `initial-version: "0.1.0"` is added as an explicit guard.

## Related

Closes #39

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Release Please from bumping the private root package to 1.0.0 by removing it from the config and manifest. Also set `apps/work-please` initial version to 0.1.0 and fix the root package name to `work-please` for consistency.

<sup>Written for commit b4af41738e8183766c260c6ff5aac99f05218514. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

