### PR TITLE
fix(release): move initial-version to root config for all packages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "initial-version": "0.1.0",
   "packages": {
     "apps/work-please": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

Move `initial-version: "0.1.0"` from the `apps/work-please` package-level config to the root config level so it applies globally to all packages.

## Why

When Release Please encounters a package at `0.0.0` (never released), it ignores the `bump-patch-for-minor-pre-major` flag and computes `1.0.0` instead of `0.1.0`. Setting `initial-version: "0.1.0"` at the root ensures the first release starts at `0.1.0` for any package added in the future, not just `apps/work-please`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `initial-version: "0.1.0"` to the root `release-please` config so all packages start at 0.1.0 on their first release. This fixes cases where packages at 0.0.0 were computed as 1.0.0 despite `bump-patch-for-minor-pre-major`.

<sup>Written for commit bf447c493172c0979388e0d31617919839a10e36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

