### PR TITLE
chore: Bump version to 0.1.0 in manifest file

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  "apps/work-please": "0.0.0"
+  "apps/work-please": "0.1.0",
+  ".": "0.1.0"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `.release-please-manifest.json` to 0.1.0 for `apps/work-please` and the repository root (`.`). This enables release-please to tag and generate release notes for both scopes.

<sup>Written for commit b2c203e1af0ceb21dc407b01b49d4a9b6b10a3a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

