### PR TITLE
chore: Bump version from 0.0.0 to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "work-please",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped root package `work-please` version from 0.0.0 to 0.1.0 to mark the first minor release and align semver across the monorepo. No code changes; config-only update to package.json.

<sup>Written for commit 94b55dad94b0782666905f27820acdfd223598e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

