### PR TITLE
fix(ci): remove release-type from release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,6 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          release-type: node
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Remove `release-type: node` from the Release Please workflow step.

## Problem

When `release-type` is specified alongside `config-file` in the release-please-action, the action registers the repository root (`"."`) as an **additional** node component — on top of whatever `packages` are defined in the config file. This caused:

- Release Please to continuously generate `0.0.0 → 1.0.0` bump PRs for the root `package.json`
- The `apps/work-please` package to never get its own release PR

## Fix

Remove `release-type: node` from the action input. Each package's release type is already declared inside `release-please-config.json`, so the workflow-level override is unnecessary.

## Related

Closes #43

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `release-type: node` from the `release-please` workflow so `release-please-config.json` exclusively defines release components. This stops root `package.json` bump PRs and restores releases for `apps/work-please`, fixing #43.

<sup>Written for commit 96dc7823e465235ee058df2e0ecb98d6688968ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

