### PR TITLE
fix(ci): remove --provenance from npm publish for private repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,5 +56,5 @@ jobs:
       - name: Copy root files into package directory
         run: cp LICENSE README.md apps/work-please/
 
-      - run: npm publish --provenance --access public
+      - run: npm publish --access public
         working-directory: apps/work-please

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,10 @@ Red → Green → Refactor → Commit → repeat
 
 Only commit when **all tests pass** and **all lint/type errors are resolved**.
 
+## CI / Release
+
+- npm publish uses **OIDC trusted publishing** (`id-token: write` required for OIDC auth) — do not add `--provenance` flag; private source repos cannot generate provenance (GitHub limitation) and the flag causes a 422 error
+
 ## Key Implementation Notes
 
 - The service is a **scheduler/runner only** — it does not write to the issue tracker itself. Ticket state transitions


### PR DESCRIPTION
## Summary

- Remove `--provenance` flag from `npm publish` — private source repositories cannot generate provenance (GitHub limitation since July 2023), and the flag causes a 422 error
- Keep `id-token: write` permission — required for OIDC trusted publishing authentication
- Add CI/Release note to `CLAUDE.md` documenting this constraint

## Test plan

- [ ] Merge → release-please creates a release → publish job runs without 422 error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `--provenance` flag from the release workflow’s `npm publish` to stop 422 errors for private source repos (GitHub cannot generate provenance for private repos). Kept OIDC trusted publishing (`id-token: write`) and documented the constraint in `CLAUDE.md`.

<sup>Written for commit 0fb1a7b87f5c9796fbdbbba6d0df755f08b75abd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

