### PR TITLE
ci: rename GitHub App credential vars in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
         with:
-          app-id: ${{ vars.PF_BOT_APP_ID }}
-          private-key: ${{ secrets.PF_BOT_PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release


### PR DESCRIPTION
## Summary

- Replace `vars.PF_BOT_APP_ID` → `vars.APP_ID`
- Replace `secrets.PF_BOT_PRIVATE_KEY` → `secrets.PRIVATE_KEY`

Aligns the workflow with the actual secret/variable names configured in the repository settings.

## Test plan

- [ ] Verify the release-please workflow triggers successfully on next merge to main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `vars.PF_BOT_APP_ID` to `vars.APP_ID` and `secrets.PF_BOT_PRIVATE_KEY` to `secrets.PRIVATE_KEY` in the release-please workflow to match repository settings. This ensures the GitHub App token is created correctly and the workflow runs without auth errors.

<sup>Written for commit a5dc62cb38ea651844656c5495aabf59da0a0881. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

