### PR TITLE
ci(codecov): add Codecov integration with coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,10 @@ jobs:
 
       - run: bun run check
 
-      - run: bun run test
+      - run: bun run test:coverage
+
+      - uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        with:
+          files: apps/work-please/coverage/lcov.info
+          flags: work-please
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .turbo/
+coverage/
 *.tsbuildinfo
 .claude/settings.local.json
 .claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Work Please
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=bugs)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
+[![codecov](https://codecov.io/gh/pleaseai/work-please/graph/badge.svg?token=do858Z1lsI)](https://codecov.io/gh/pleaseai/work-please)
 
 Work Please turns issue tracker tasks into isolated, autonomous implementation runs — managing work
 instead of supervising coding agents.

--- a/apps/work-please/package.json
+++ b/apps/work-please/package.json
@@ -25,7 +25,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "check": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "test:coverage": "bun test --coverage --coverage-reporter=lcov"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.72",

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+flags:
+  work-please:
+    paths:
+      - apps/work-please/src/
+    carryforward: true

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:app": "turbo run check --filter=@pleaseai/work",
     "test": "turbo run test",
     "test:app": "turbo run test --filter=@pleaseai/work",
+    "test:coverage": "turbo run test:coverage",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,10 @@
     },
     "test": {
       "dependsOn": ["build"]
+    },
+    "test:coverage": {
+      "dependsOn": ["build"],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `codecov.yml` with project/patch status checks and `work-please` flag (carryforward enabled)
- Update CI workflow: replace `bun run test` with `bun run test:coverage`, upload lcov report via `codecov/codecov-action@v5.4.3` (pinned SHA)
- Add `test:coverage` script to `apps/work-please/package.json` (`bun test --coverage --coverage-reporter=lcov`)
- Add `test:coverage` turbo task with `cache: false` (coverage should always be fresh)
- Add `coverage/` to `.gitignore`
- Add Codecov badge to README

## Test plan

- [x] `bun run test:coverage` runs successfully (379 tests pass, `coverage/lcov.info` generated)
- [ ] CI uploads coverage to Codecov on PR/push
- [ ] Codecov dashboard shows coverage report
- [ ] `CODECOV_TOKEN` secret is set in repository settings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Codecov coverage reporting to CI so PRs and pushes upload LCOV for `apps/work-please` with project and patch checks.

- **New Features**
  - Add `codecov.yml` with project/patch checks (auto target, 1% threshold) and `work-please` flag (paths set, carryforward).
  - CI runs `bun run test:coverage` and uploads `apps/work-please/coverage/lcov.info` via `codecov/codecov-action@v5.4.3` using `CODECOV_TOKEN`.
  - Add `test:coverage` in `apps/work-please` and root `test:coverage` via `turbo` with `cache: false` for fresh reports.
  - Ignore `coverage/` and add a Codecov badge to README.

- **Migration**
  - Set the `CODECOV_TOKEN` repository secret.

<sup>Written for commit 9650851176d1dda4884224abee134d82f0a0d0d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

