### PR TITLE
docs(readme): add SonarCloud quality badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Work Please
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=bugs)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=bugs)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
 
 Work Please turns issue tracker tasks into isolated, autonomous implementation runs — managing work
 instead of supervising coding agents.


### PR DESCRIPTION
## Summary

- Add Quality Gate Status badge for overall project health
- Add Bugs badge to surface detected bug count
- Add Code Smells badge for maintainability visibility
- Add Duplicated Lines (%) badge for code duplication tracking

All badges link to the SonarCloud summary for `pleaseai_work-please`.

## Test plan

- [ ] Verify badges render correctly in GitHub markdown preview
- [ ] Confirm badge links navigate to the correct SonarCloud project page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SonarCloud quality badges to the README to show project health at a glance. Includes Quality Gate Status, Bugs, Code Smells, and Duplicated Lines (%) badges, all linking to the `pleaseai_work-please` SonarCloud summary and rendered on a single line for side-by-side display.

<sup>Written for commit 31bd639f2809d5b74ce6a04b71113ccced1a1fab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

