### PR TITLE
chore(claude): enable sandbox with GPG agent socket access

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,5 +83,9 @@
         ]
       }
     ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "allowUnixSockets": ["~/.gnupg/S.gpg-agent"]
   }
 }


### PR DESCRIPTION
## Summary

- Enable Claude Code sandbox mode in `.claude/settings.json`
- Allow Unix socket access for GPG agent (`~/.gnupg/S.gpg-agent`) to support signed commits within sandbox

## Test plan

- [ ] Verify Claude Code runs correctly with sandbox enabled
- [ ] Verify GPG-signed commits work within the sandbox environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Claude Code sandbox in `.claude/settings.json`. Allows Unix socket access to the local GPG agent (`~/.gnupg/S.gpg-agent`) so signed commits work inside the sandbox.

<sup>Written for commit 68eaadbe6eadaaa4d63df49d60bdb088e16796cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

