### PR TITLE
fix(build): prepend shebang to dist/index.js for global install

### DIFF
--- a/apps/work-please/package.json
+++ b/apps/work-please/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "prepublishOnly": "cp ../../LICENSE ../../README.md .",
     "postpublish": "rm -f LICENSE README.md",
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun && printf '#!/usr/bin/env bun\n' | cat - ./dist/index.js > ./dist/index.tmp && mv ./dist/index.tmp ./dist/index.js",
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun && bun run scripts/add-shebang.ts",
     "dev": "bun run --watch src/index.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/apps/work-please/scripts/add-shebang.ts
+++ b/apps/work-please/scripts/add-shebang.ts
@@ -1,0 +1,6 @@
+import { join } from 'node:path'
+import { file, write } from 'bun'
+
+const distFile = join(import.meta.dir, '../dist/index.js')
+const content = await file(distFile).text()
+await write(distFile, `#!/usr/bin/env bun\n${content}`)


### PR DESCRIPTION
## Summary

- `bun build` does not automatically add a shebang line to the output bundle
- When `@pleaseai/work` is installed globally via `bun add -g`, running `work-please` fails because the OS tries to execute `dist/index.js` as a shell script
- Update the `build` script to prepend `#!/usr/bin/env bun` to `dist/index.js` after bundling using `printf | cat - | mv` pattern

## Test plan

- [ ] `bun run build` completes successfully
- [ ] `head -1 dist/index.js` outputs `#!/usr/bin/env bun`
- [ ] `chmod +x dist/index.js && ./dist/index.js --help` executes without error
- [ ] `bun run test` passes all tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepend a bun shebang to `dist/index.js` during build so the `work-please` CLI runs when `@pleaseai/work` is installed globally. The build now runs `scripts/add-shebang.ts` to inject `#!/usr/bin/env bun` after bundling for a portable, readable setup.

<sup>Written for commit 56a4623b4ede9665450ca2c3b0edeeb84ea9b5cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

