### PR TITLE
chore: translate .worktreeinclude comments to English

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,15 @@
+# Turbo cache (speeds up incremental builds)
+.turbo/
+
+# TypeScript build info cache
+*.tsbuildinfo
+
+# Nuxt Nitro generated files
+packages/web/.nitro/
+
+# Local environment overrides (required for DB, API connections)
+.env.local
+.env.*.local
+
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Translate Korean comments in `.worktreeinclude` to English

## Test plan
- N/A (documentation-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated comments in `.worktreeinclude` to English to clarify entries for Turbo cache, TypeScript build info, Nuxt Nitro output, local env overrides, and Claude Code settings.

<sup>Written for commit 5dc4a4fd00f479eff435ea26a07c3360d05395b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

