### PR TITLE
feat(cli): add --version / -V flag

### DIFF
--- a/apps/work-please/src/cli.test.ts
+++ b/apps/work-please/src/cli.test.ts
@@ -128,12 +128,12 @@ describe('parseArgs - --port flag', () => {
 })
 
 describe('parseArgs - --version / -V flag', () => {
-  it('does not throw when --version is passed', () => {
-    expect(() => parseArgs(['--version'])).not.toThrow()
-  })
-
-  it('does not throw when -V is passed', () => {
-    expect(() => parseArgs(['-V'])).not.toThrow()
+  it.each([
+    ['--version'],
+    ['-V'],
+  ])('returns command version when %s is passed', (flag) => {
+    const result = parseArgs([flag])
+    expect(result.command).toBe('version')
   })
 })
 

--- a/apps/work-please/src/cli.ts
+++ b/apps/work-please/src/cli.ts
@@ -2,14 +2,14 @@ import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import { Command, CommanderError } from 'commander'
-import pkg from '../package.json'
+import pkg from '../package.json' with { type: 'json' }
 import { runInit } from './init'
 import { Orchestrator } from './orchestrator'
 import { HttpServer } from './server'
 import { WORKFLOW_FILE_NAME } from './workflow'
 
 export interface ParsedArgs {
-  command: 'run' | 'init'
+  command: 'run' | 'init' | 'version'
   workflowPath: string
   portOverride: number | null
   initOptions: { owner: string | null, title: string | null, token: string | null } | null
@@ -17,6 +17,9 @@ export interface ParsedArgs {
 
 export async function runCli(argv: string[]): Promise<void> {
   const parsed = parseArgs(argv.slice(2))
+
+  if (parsed.command === 'version')
+    return
 
   if (parsed.command === 'init') {
     await runInit(parsed.initOptions!)
@@ -134,7 +137,9 @@ export function parseArgs(args: string[]): ParsedArgs {
   }
   catch (err) {
     if (err instanceof CommanderError) {
-      const informational = new Set(['commander.help', 'commander.helpDisplayed', 'commander.version'])
+      if (err.code === 'commander.version')
+        return { ...result, command: 'version' }
+      const informational = new Set(['commander.help', 'commander.helpDisplayed'])
       if (informational.has(err.code))
         return result
       console.error(err.message)


### PR DESCRIPTION
## Summary

- Import `version` from `package.json` via Bun's native JSON import support
- Register `program.version(pkg.version)` so commander exposes `-V` / `--version`
- The existing `commander.version` error code in the `exitOverride` catch block already handles this gracefully (returns without throwing)

## Test plan

- [x] `parseArgs(['--version'])` does not throw
- [x] `parseArgs(['-V'])` does not throw
- [x] 381 tests pass (`bun run test:app`)
- [x] Type check passes (`bun run check:app`)
- [x] Lint passes (`bun run lint:app`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--version` / `-V` flags to print the package version via `commander`, reading from `package.json` with Bun’s JSON import. Explicitly handle the version exit to return `command: 'version'` and exit early; tests added for both flags.

<sup>Written for commit 86963856c97ef52ce54cd284ce6f5a55ed5f49ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

