### PR TITLE
docs(readme): fix license name and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ Start with `default` or `acceptEdits` unless you are running in a fully isolated
 
 ## License
 
-Apache License 2.0. See [LICENSE](vendor/symphony/LICENSE) for details.
+Functional Source License 1.1, MIT Future License (FSL-1.1-MIT). See [LICENSE](LICENSE) for details.
 
 Work Please is a TypeScript implementation based on the
 [Symphony specification](vendor/symphony/SPEC.md) by OpenAI (Apache 2.0).


### PR DESCRIPTION
## Summary

- Fix incorrect license name: `Apache License 2.0` → `Functional Source License 1.1, MIT Future License (FSL-1.1-MIT)`
- Fix broken LICENSE link: `vendor/symphony/LICENSE` → `LICENSE` (project root)

## Changes

The root `LICENSE` file contains FSL-1.1-MIT (Passion Factory, Inc.), not Apache 2.0. The README was referencing the Symphony vendor license instead of the project's own license file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the README to show the correct license and link. Replaces "Apache License 2.0" with "Functional Source License 1.1, MIT Future License (FSL-1.1-MIT)" and updates the LICENSE link from `vendor/symphony/LICENSE` to the root `LICENSE`.

<sup>Written for commit e65bffa4fb39f2a9fae7e30ae59b9777011daf9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

