### PR TITLE
docs(readme): add Korean, Japanese, and Simplified Chinese translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Work Please
 
-[English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
+[English](README.md) | [한국어](README.ko.md) | 日本語 | [简体中文](README.zh-CN.md)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=bugs)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
 [![codecov](https://codecov.io/gh/pleaseai/work-please/graph/badge.svg?token=do858Z1lsI)](https://codecov.io/gh/pleaseai/work-please)
@@ -122,7 +122,7 @@ Config Layer ──> Orchestrator ──> Workspace Manager ──> Agent Runner
 ### インストール
 
 ```bash
-git clone https://github.com/chatbot-pf/work-please.git
+git clone https://github.com/pleaseai/work-please.git
 cd work-please
 bun install
 bun run build

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # Work Please
 
-[English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+[English](README.md) | 한국어 | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=bugs)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
 [![codecov](https://codecov.io/gh/pleaseai/work-please/graph/badge.svg?token=do858Z1lsI)](https://codecov.io/gh/pleaseai/work-please)
@@ -122,7 +122,7 @@ Config Layer ──> Orchestrator ──> Workspace Manager ──> Agent Runner
 ### 설치
 
 ```bash
-git clone https://github.com/chatbot-pf/work-please.git
+git clone https://github.com/pleaseai/work-please.git
 cd work-please
 bun install
 bun run build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Work Please
 
-[한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+English | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=bugs)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
 [![codecov](https://codecov.io/gh/pleaseai/work-please/graph/badge.svg?token=do858Z1lsI)](https://codecov.io/gh/pleaseai/work-please)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # Work Please
 
-[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | 简体中文
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=bugs)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_work-please&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=pleaseai_work-please)
 [![codecov](https://codecov.io/gh/pleaseai/work-please/graph/badge.svg?token=do858Z1lsI)](https://codecov.io/gh/pleaseai/work-please)
@@ -122,7 +122,7 @@ Config Layer ──> Orchestrator ──> Workspace Manager ──> Agent Runner
 ### 安装
 
 ```bash
-git clone https://github.com/chatbot-pf/work-please.git
+git clone https://github.com/pleaseai/work-please.git
 cd work-please
 bun install
 bun run build


### PR DESCRIPTION
## Summary

- Add `README.ko.md` with full Korean translation of the README
- Add `README.ja.md` with full Japanese translation of the README
- Add `README.zh-CN.md` with full Simplified Chinese translation of the README
- Add language switch links between all four README files

## Test plan

- [ ] Verify `README.ko.md` renders correctly on GitHub
- [ ] Verify `README.ja.md` renders correctly on GitHub
- [ ] Verify `README.zh-CN.md` renders correctly on GitHub
- [ ] Verify language links work across all four files