### PR TITLE
docs: add TypeScript Agent SDK reference link to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,5 @@ Only commit when **all tests pass** and **all lint/type errors are resolved**.
   and PR links are performed by the Claude Code agent.
 - `WORKFLOW.md` supports `$ENV_VAR` references in the `api_key` field — the config layer must resolve these at startup.
 - Prompt templates use Liquid-compatible syntax (`{{ issue.title }}`, `{% if %}` blocks).
-- Agent runs use `@anthropic-ai/claude-agent-sdk` (`query()`) to invoke Claude Code programmatically.
-  See the [TypeScript SDK reference](https://platform.claude.com/docs/en/agent-sdk/typescript.md).
+- Agent runs use [`@anthropic-ai/claude-agent-sdk`](https://platform.claude.com/docs/en/agent-sdk/typescript.md) (`query()`) to invoke Claude Code programmatically.
 - Workspace paths must be validated against `workspace.root` before launch (path traversal prevention).


### PR DESCRIPTION
## Summary

- Add TypeScript Agent SDK reference link next to the existing `@anthropic-ai/claude-agent-sdk` mention in CLAUDE.md
- Links to https://platform.claude.com/docs/en/agent-sdk/typescript.md for quick API reference during implementation

## Test plan

- [x] Verify link renders correctly in CLAUDE.md
- [x] No other files changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline a link to the TypeScript Agent SDK reference on the `@anthropic-ai/claude-agent-sdk` mention in CLAUDE.md for a quick path to the API docs: https://platform.claude.com/docs/en/agent-sdk/typescript.md.

<sup>Written for commit c39e31c10d5a954f35fb0f1402bfb9fdb0b54de1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

