### PR TITLE
chore: remove unused plugins and registry from claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,6 @@
     "bun@passionfactory": true,
     "claude-code-setup@passionfactory": true,
     "claude-md-management@pleaseai": true,
-    "code-review@pleaseai": true,
     "context@passionfactory": true,
     "dev-tools@passionfactory": true,
     "eslint-lsp@code-intelligence": true,
@@ -21,14 +20,12 @@
     "frontend@passionfactory": true,
     "gardening@passionfactory": true,
     "gatekeeper@pleaseai": true,
-    "genkit@passionfactory": true,
     "github@passionfactory": true,
     "graphql-lsp@code-intelligence": true,
     "graphql@passionfactory": true,
     "markitdown@pleaseai": true,
     "please@passionfactory": true,
     "ralph-loop@claude-plugins-official": true,
-    "reflexion@passionfactory": false,
     "research@passionfactory": true,
     "review@passionfactory": true,
     "spec-kit@pleaseai": true,
@@ -52,13 +49,6 @@
       "source": {
         "source": "github",
         "repo": "pleaseai/claude-code-plugins"
-      },
-      "autoUpdate": true
-    },
-    "mastra-agent-skills": {
-      "source": {
-        "source": "github",
-        "repo": "amondnet/mastra-agent-skills"
       },
       "autoUpdate": true
     },


### PR DESCRIPTION
## Summary

- Remove unused plugin references: `code-review@pleaseai`, `genkit@passionfactory`, `reflexion@passionfactory`
- Remove `mastra-agent-skills` registry entry that is no longer needed

## Test plan

- [x] Verify `.claude/settings.json` is valid JSON
- [ ] Confirm Claude Code loads without errors with updated settings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused plugin entries from `.claude/settings.json` to simplify settings and avoid loading unused integrations. Dropped `code-review@pleaseai`, `genkit@passionfactory`, `reflexion@passionfactory`, and the `mastra-agent-skills` registry.

<sup>Written for commit e24e165ee531204eb515668a6e73dfbed7f3cefd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

