### PR TITLE
docs(workflow): add reply and resolve step to PR feedback sweep

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -261,8 +261,10 @@ When a ticket has an attached PR, run this protocol before moving to `Human Revi
 3. Treat every actionable reviewer comment (human or bot), including inline review comments, as blocking until one of these is true:
    - code/test/docs updated to address it, or
    - explicit, justified pushback reply is posted on that thread.
-4. After addressing a comment (code update or pushback reply), reply explaining what was done (`gh api … pulls/<pr>/comments/<id>/replies -f body='…'`).
-   For **bot threads only** (`user.type == "Bot"` in the comment payload), also resolve the thread (`gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<id>"}) { thread { id } } }'`).
+4. After addressing a comment (code update or pushback reply), reply explaining what was done:
+   - Inline review comments: `gh api … pulls/<pr>/comments/<comment-id>/replies -f body='…'`
+   - Top-level PR comments: `gh api … issues/<pr>/comments -f body='…'`
+   For **bot threads only** (`user.type == "Bot"` on the review comment), also resolve the thread using its GraphQL thread ID (from `reviewThreads.nodes[].id`, not the comment `id`): `gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<thread-id>"}) { thread { id } } }'`.
    Leave human reviewer threads unresolved — let the reviewer confirm and resolve themselves.
    @mention the comment author when replying, **except Copilot** — mentioning Copilot triggers unwanted auto-fix PRs.
 5. Update the workpad plan/checklist to include each feedback item and its resolution status.


### PR DESCRIPTION
## Summary

- Add step 4 to the PR feedback sweep protocol: reply to addressed comments and resolve **bot threads only**
- Bot threads identified by `user.type == "Bot"` in the comment payload
- Human reviewer threads left unresolved — reviewer confirms and resolves themselves
- Renumber existing steps 4–6 → 5–7

## Test plan

- [ ] Review WORKFLOW.md step numbering is correct (1–7)
- [ ] Verify bot identification guidance (`user.type == "Bot"`) is clear
- [ ] Confirm `gh api` command examples are accurate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a reply-and-resolve step to the PR feedback sweep: after addressing a comment, reply with what changed, @mention the author (except Copilot), and resolve bot threads only (`user.type == "Bot"`); leave human threads open. Clarifies `gh api` usage (different endpoints for inline review vs top-level PR comments) and that resolving requires the GraphQL thread ID from `reviewThreads.nodes[].id` (not the comment ID); steps renumbered 4–6 → 5–7.

<sup>Written for commit fb19efb9aabe2f1dedc099d049f1ca5d75425d22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

