### PR TITLE
docs: fix stale URLs, outdated labels, and key name inconsistencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Code + Asana/GitHub Projects v2. The reference implementation in Elixir/OTP live
 - `packages/*` — shared libraries (none yet scaffolded)
 - `vendor/symphony/` — upstream Symphony reference (read-only, excluded from ESLint/TS)
 
-**Intended component boundaries** (per SPEC.md — not yet implemented):
+**Intended component boundaries** (per SPEC.md):
 
 | Component            | Responsibility                                                 |
 |----------------------|----------------------------------------------------------------|
@@ -87,7 +87,7 @@ Code + Asana/GitHub Projects v2. The reference implementation in Elixir/OTP live
 | Issue Tracker Client | Asana REST or GitHub Projects v2 GraphQL; poll + reconcile     |
 | Orchestrator         | In-memory state; poll/dispatch/retry loop                      |
 | Workspace Manager    | Create/reuse per-issue directories; run lifecycle hooks        |
-| Agent Runner         | Launch `claude` CLI; stream JSON events back                   |
+| Agent Runner         | Invoke Claude Code via `@anthropic-ai/claude-agent-sdk` (`query()`); stream events back |
 | Status Surface       | Optional HTTP dashboard + structured `key=value` logs          |
 
 **WORKFLOW.md** is a user-created file in a _target repository_ (not this repo). It contains YAML front matter (tracker
@@ -158,7 +158,7 @@ Only commit when **all tests pass** and **all lint/type errors are resolved**.
 
 - The service is primarily a **scheduler/runner** — the orchestrator makes two narrow tracker writes (auto-transition
   state changes and status labels). All other state transitions and PR links are performed by the Claude Code agent.
-- `WORKFLOW.md` supports `$ENV_VAR` references in the `api_key` field — the config layer must resolve these at startup.
+- `WORKFLOW.md` supports `$ENV_VAR` references in the `api_key`, `app_id`, `private_key`, and `installation_id` credential fields — the config layer must resolve these at startup.
 - Prompt templates use Liquid-compatible syntax (`{{ issue.title }}`, `{% if %}` blocks).
 - Agent runs use [`@anthropic-ai/claude-agent-sdk`](https://platform.claude.com/docs/en/agent-sdk/typescript.md) (`query()`) to invoke Claude Code programmatically.
 - Workspace paths must be validated against `workspace.root` before launch (path traversal prevention).

--- a/README.ja.md
+++ b/README.ja.md
@@ -155,7 +155,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true
@@ -231,7 +231,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true

--- a/README.ko.md
+++ b/README.ko.md
@@ -155,7 +155,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true
@@ -231,7 +231,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ See [SPEC.md](SPEC.md) for the full specification.
 ### Install
 
 ```bash
-git clone https://github.com/chatbot-pf/work-please.git
+git clone https://github.com/pleaseai/work-please.git
 cd work-please
 bun install
 bun run build
@@ -159,7 +159,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true
@@ -235,7 +235,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,7 +155,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true
@@ -231,7 +231,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -4,7 +4,7 @@ tracker:
   owner: "<org-or-user>"
   project_number: 1
   # api_key: $GITHUB_TOKEN          # optional; auto-resolves from GITHUB_TOKEN env
-  active_states:
+  active_statuses:
     - Todo
     - In Progress
     - Merging
@@ -15,7 +15,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true


### PR DESCRIPTION
- Fix git clone URL from chatbot-pf to pleaseai org in README.md
- Remove outdated "not yet implemented" label from component boundaries
- Rename active_states/watched_states to active_statuses/watched_statuses across WORKFLOW.md and all README translations for consistency
- Update Agent Runner description to reference claude-agent-sdk
- Expand $ENV_VAR note to cover all credential fields

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale docs and aligns examples with current config and SDK usage. Standardizes key names and expands env var guidance across READMEs and WORKFLOW.

- **Docs**
  - Update clone URL to https://github.com/pleaseai/work-please.git
  - Remove “not yet implemented” note from component boundaries in `CLAUDE.md`
  - Rename `active_states`/`watched_states` to `active_statuses`/`watched_statuses` in `WORKFLOW.md` and all README translations
  - Reference `@anthropic-ai/claude-agent-sdk` (`query()`) for the Agent Runner
  - Note `$ENV_VAR` support for `api_key`, `app_id`, `private_key`, and `installation_id` credentials

<sup>Written for commit e75a4a06f380c641c91d66e2b876531f7126cfef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

