### PR TITLE
docs: fix stale docs from gardening sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Code + Asana/GitHub Projects v2. The reference implementation in Elixir/OTP live
 - `packages/*` — shared libraries (none yet scaffolded)
 - `vendor/symphony/` — upstream Symphony reference (read-only, excluded from ESLint/TS)
 
-**Intended component boundaries** (per SPEC.md — not yet implemented):
+**Intended component boundaries** (per SPEC.md):
 
 | Component            | Responsibility                                                 |
 |----------------------|----------------------------------------------------------------|
@@ -87,7 +87,7 @@ Code + Asana/GitHub Projects v2. The reference implementation in Elixir/OTP live
 | Issue Tracker Client | Asana REST or GitHub Projects v2 GraphQL; poll + reconcile     |
 | Orchestrator         | In-memory state; poll/dispatch/retry loop                      |
 | Workspace Manager    | Create/reuse per-issue directories; run lifecycle hooks        |
-| Agent Runner         | Launch `claude` CLI; stream JSON events back                   |
+| Agent Runner         | Invoke Claude Code via `@anthropic-ai/claude-agent-sdk` (`query()`); stream events back |
 | Status Surface       | Optional HTTP dashboard + structured `key=value` logs          |
 
 **WORKFLOW.md** is a user-created file in a _target repository_ (not this repo). It contains YAML front matter (tracker
@@ -158,7 +158,7 @@ Only commit when **all tests pass** and **all lint/type errors are resolved**.
 
 - The service is primarily a **scheduler/runner** — the orchestrator makes two narrow tracker writes (auto-transition
   state changes and status labels). All other state transitions and PR links are performed by the Claude Code agent.
-- `WORKFLOW.md` supports `$ENV_VAR` references in the `api_key` field — the config layer must resolve these at startup.
+- `WORKFLOW.md` supports `$ENV_VAR` references in the `api_key`, `app_id`, `private_key`, and `installation_id` credential fields — the config layer must resolve these at startup.
 - Prompt templates use Liquid-compatible syntax (`{{ issue.title }}`, `{% if %}` blocks).
 - Agent runs use [`@anthropic-ai/claude-agent-sdk`](https://platform.claude.com/docs/en/agent-sdk/typescript.md) (`query()`) to invoke Claude Code programmatically.
 - Workspace paths must be validated against `workspace.root` before launch (path traversal prevention).

--- a/README.ja.md
+++ b/README.ja.md
@@ -155,7 +155,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true
@@ -231,7 +231,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true

--- a/README.ko.md
+++ b/README.ko.md
@@ -155,7 +155,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true
@@ -231,7 +231,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ See [SPEC.md](SPEC.md) for the full specification.
 ### Install
 
 ```bash
-git clone https://github.com/chatbot-pf/work-please.git
+git clone https://github.com/pleaseai/work-please.git
 cd work-please
 bun install
 bun run build
@@ -159,7 +159,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true
@@ -235,7 +235,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,7 +155,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true
@@ -231,7 +231,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -4,7 +4,7 @@ tracker:
   owner: "<org-or-user>"
   project_number: 1
   # api_key: $GITHUB_TOKEN          # optional; auto-resolves from GITHUB_TOKEN env
-  active_states:
+  active_statuses:
     - Todo
     - In Progress
     - Merging
@@ -15,7 +15,7 @@ tracker:
     - Canceled
     - Duplicate
     - Done
-  watched_states:
+  watched_statuses:
     - Human Review
   auto_transitions:
     human_review_to_rework: true


### PR DESCRIPTION
## Summary

- Add missing `env:` config section to Front Matter Schema in all READMEs
- Add `agent-env.ts` to ARCHITECTURE.md module structure
- Record orchestrator.ts 762 LOC tech debt in tracker (TD-001)
- Fix `terminal_states` → `terminal_statuses` key in WORKFLOW.md

## Changes

These are documentation-only fixes discovered during a gardening sweep:

- **README / WORKFLOW.md schema docs**: The `env:` key was present in the implementation and examples but missing from the Front Matter Schema reference sections — added consistently across all docs.
- **ARCHITECTURE.md**: `agent-env.ts` module was scaffolded but not listed in the architecture module table.
- **Tech debt tracker**: Logged TD-001 for `orchestrator.ts` exceeding the 500 LOC file limit (currently 762 LOC).
- **WORKFLOW.md key name**: Corrected `terminal_states` to `terminal_statuses` to match the actual config parsing code.

## Test Plan

- [ ] Verify all README front matter schema sections include the `env:` key
- [ ] Verify ARCHITECTURE.md lists `agent-env.ts` in the module structure
- [ ] Verify WORKFLOW.md uses `terminal_statuses` (not `terminal_states`)
- [ ] Confirm no functional code was changed (docs-only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only cleanup to fix stale URLs and align config keys with the implementation. Updates WORKFLOW/README examples to use `*_statuses` and clarifies the agent runner reference.

- **Bug Fixes**
  - Rename `active_states`/`watched_states` to `active_statuses`/`watched_statuses` in `WORKFLOW.md` and all READMEs (including translations).
  - Update clone URL in `README.md` to `https://github.com/pleaseai/work-please.git`.
  - Reference `@anthropic-ai/claude-agent-sdk` for the Agent Runner and expand `$ENV_VAR` support note to include `api_key`, `app_id`, `private_key`, `installation_id`.
  - Remove outdated “not yet implemented” label from component boundaries.

<sup>Written for commit e75a4a06f380c641c91d66e2b876531f7126cfef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

