### PR TITLE
fix(workflow): prevent duplicate workpad comment creation

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -307,7 +307,7 @@ Use this only when completion is blocked by missing required tools or missing au
 1.  Determine current repo state (`branch`, `git status`, `HEAD`) and verify the kickoff sync result is already recorded in the workpad before implementation continues.
 2.  If current issue state is `Todo`, move it to `In Progress`; otherwise leave the current state unchanged.
 3.  Load the existing workpad comment and treat it as the active execution checklist.
-    - Edit it liberally via `gh api repos/<owner>/<repo>/issues/comments/<comment-id> -X PATCH -F body=@- <<'EOF' … EOF` whenever reality changes (scope, risks, validation approach, discovered tasks).
+    - Edit it liberally via `PATCH` (piping the body through a heredoc as shown in Step 1) whenever reality changes (scope, risks, validation approach, discovered tasks).
     - Never post a new comment to update progress — always `PATCH` the existing workpad comment.
 4.  Implement against the hierarchical TODOs and keep the comment current:
     - Check off completed items.


### PR DESCRIPTION
## Summary

- Add concrete `gh api` commands for searching existing workpad comments before creating new ones
- Add explicit `PATCH` command for updating existing comments instead of creating duplicates
- Add `<!-- workpad:issue-<number> -->` HTML marker to the workpad template for reliable machine-readable search
- Add attribution footer (`🙏 Generated with Work Please`)
- Strengthen guardrails and continuation context with duplicate prevention instructions

## Context

Reported in https://github.com/chatbot-pf/workflow/issues/3 — the agent created two `## Workpad` comments instead of updating the existing one.

**Root cause:** The WORKFLOW.md instructions lacked concrete `gh` CLI commands for finding and updating existing workpad comments. The agent used `gh issue comment` (always creates new) instead of `gh api ... PATCH` (updates in place).

## Changes

1. **Continuation context**: Reminder that a workpad from a previous attempt likely already exists
2. **Step 1 — workpad search/create**: Concrete `gh api` commands for search (HTML marker + header fallback), PATCH update, and conditional create
3. **Step 2 — execution phase**: Explicit PATCH command and "never post new comment" instruction
4. **Guardrails**: Strengthened one-workpad rule with concrete search/PATCH instructions
5. **Workpad template**: Added `<!-- workpad:issue-<number> -->` footer marker and attribution

## Test plan

- [ ] Deploy and run agent on a test issue — verify only one workpad comment is created
- [ ] Trigger a retry — verify existing workpad is found and updated via PATCH, no duplicate created

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate workpad comments by adding concrete `gh api` search and `PATCH` update steps and a machine-readable marker. Uses heredoc piping to avoid quoting issues.

- **Bug Fixes**
  - Added `<!-- workpad:issue-<number> -->` marker for reliable search.
  - Consolidated search to a single `jq` filter (marker or `## Workpad`); updates use `gh api ... -X PATCH -F body=@-` with heredoc, and Step 2 now references the Step 1 heredoc example instead of an inline snippet.
  - Create a workpad only if none exists; persist the comment ID and always `PATCH` the same comment.
  - Strengthened guardrails and continuation context; added attribution footer.

<sup>Written for commit 05cd019704c1da8a83bd7505d360ded5bae30390. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

