### PR TITLE
build(setup): add mise for project setup and tool versioning

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-bun = "1.3"
+bun = "1.3.10"
 
 [tasks.setup]
 description = "Initialize project (submodules + dependencies)"

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
     "scripts": {
-        "setup": "command -v mise >/dev/null || curl https://mise.run | sh && mise run setup"
+        "setup": "(command -v mise >/dev/null || curl -fsSL https://mise.run | sh) && mise trust --yes && mise run setup"
     }
 }


### PR DESCRIPTION
## Summary

- Add `.mise.toml` to pin Bun version and define setup task
- Update `conductor.json` to install mise if missing, then delegate to `mise run setup`
- Ensures `git submodule update --init --recursive` runs before `bun install`

## Changes

- **`.mise.toml`** (new): Pin `bun = "1.3.10"`, define `setup` task (submodule init + bun install)
- **`conductor.json`**: Setup script installs mise if absent, trusts config, runs `mise run setup`

## Two setup paths

| User | Command |
|------|---------|
| Conductor users | Auto-runs `conductor.json` setup |
| Everyone else | `mise run setup` |

## Test plan

- [ ] Fresh clone without mise installed — verify mise gets installed and setup completes
- [ ] Fresh clone with mise installed — verify setup runs correctly
- [ ] Verify `bun install` succeeds after submodule init
- [ ] Verify `mise ls` shows `bun 1.3.10`