### PR TITLE
docs(research): update graphql cost analysis to reflect O5 applied

### DIFF
--- a/.please/docs/research/github-graphql-cost-analysis.md
+++ b/.please/docs/research/github-graphql-cost-analysis.md
@@ -128,7 +128,7 @@ At 30s polling → ~20 pts/min → **~1,200 pts/hr** (well within 5,000 limit).
 ### Typical tick (5 running, 1 page, with filter)
 
 ```
-Reconcile:                         1 pt
+Reconcile:                         1 pt   (N=5, ceil((1+10)/100) = 1)
 Candidates (filtered):             4 pts  (1 page)
 Watched (unfiltered, parallel):    4 pts  (1 page)
                                  ────────
@@ -200,5 +200,6 @@ Double interval from 30s to 60s halves hourly cost.
 | Per hour (30s poll, no filter) | 13,680 pts | 1,680 pts | 1,200 pts |
 | Per hour (30s poll, with filter) | 13,680 pts | 1,680 pts | 1,680 pts |
 | Per hour (60s poll, no filter) | 6,840 pts | 840 pts | 600 pts |
+| Per hour (60s poll, with filter) | 6,840 pts | 840 pts | 840 pts |
 
 O1 and O5 are both applied as of 2026-03-15.


### PR DESCRIPTION
## Summary

- Update per-tick cost section to reflect PR #103 merged candidate and watched state fetches into a single combined call (`fetchCandidateAndWatchedIssues`)
- Add filter vs no-filter cost breakdowns (no-filter: 5 pts/tick, with-filter: 9 pts/tick)
- Mark O5 optimization as APPLIED in the optimization opportunities list
- Update projected cost table with current state (O1+O5 both applied)

## Test plan

- [x] Documentation-only change, no code affected
- [x] Cost numbers verified against PR #103 implementation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the GitHub GraphQL cost analysis to reflect O5 applied: candidates and watched issues are fetched together via `fetchCandidateAndWatchedIssues` (saving ~4 pts/tick with no filter).
Adds no-filter vs filtered breakdowns (5 vs 9 pts/tick; 10 vs 14 with agent turns), clarifies the Reconcile calculation in the filtered scenario, and updates the projected cost table with O1+O5 as current, including the 60s‑poll with‑filter row.

<sup>Written for commit c7fea1e36f97e8b4d42f08b4a2f0aa62f09ddf3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

