### PR TITLE
fix(cli): prevent --help from starting the server

### DIFF
--- a/apps/work-please/src/cli.test.ts
+++ b/apps/work-please/src/cli.test.ts
@@ -154,6 +154,12 @@ describe('parseArgs - --version / -V flag', () => {
     const result = parseArgs([flag])
     expect(result.command).toBe('version')
   })
+
+  it('preserves --verbose with --version', () => {
+    const result = parseArgs(['--verbose', '--version'])
+    expect(result.command).toBe('version')
+    expect(result.verbose).toBe(true)
+  })
 })
 
 describe('parseArgs - --help / -h flag', () => {
@@ -163,6 +169,12 @@ describe('parseArgs - --help / -h flag', () => {
   ])('returns command help when %s is passed', (flag) => {
     const result = parseArgs([flag])
     expect(result.command).toBe('help')
+  })
+
+  it('preserves --verbose with --help', () => {
+    const result = parseArgs(['--verbose', '--help'])
+    expect(result.command).toBe('help')
+    expect(result.verbose).toBe(true)
   })
 })
 

--- a/apps/work-please/src/cli.ts
+++ b/apps/work-please/src/cli.ts
@@ -149,11 +149,15 @@ export function parseArgs(args: string[]): ParsedArgs {
   }
   catch (err) {
     if (err instanceof CommanderError) {
-      if (err.code === 'commander.version')
-        return { ...result, command: 'version' }
+      if (err.code === 'commander.version') {
+        const globalOpts = program.opts<{ verbose?: boolean }>()
+        return { ...result, command: 'version', verbose: globalOpts.verbose === true }
+      }
       const informational = new Set(['commander.help', 'commander.helpDisplayed'])
-      if (informational.has(err.code))
-        return { ...result, command: 'help' }
+      if (informational.has(err.code)) {
+        const globalOpts = program.opts<{ verbose?: boolean }>()
+        return { ...result, command: 'help', verbose: globalOpts.verbose === true }
+      }
       log.error(err.message)
       process.exit(err.exitCode)
     }


### PR DESCRIPTION
## Summary

- `work-please --help` was starting the server instead of showing help and exiting
- When Commander's `exitOverride()` caught a help error, the handler returned `result` with `command: 'run'` unchanged
- Now returns `command: 'help'` (matching how `--version` is handled) and exits early in `runCli`

## Test plan

- [x] Added test: `parseArgs` returns `command: 'help'` for `--help` and `-h`
- [x] All 567 existing tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI so `work-please --help` and `-h` show help and exit without starting the server. Also preserves `--verbose` on early exits for `--help` and `--version`.

- **Bug Fixes**
  - Return `command: 'help'` from `parseArgs` on `--help`/`-h`, and exit early in `runCli` to prevent server start.
  - Preserve `--verbose` in early-exit paths (`--help`, `--version`), with tests added for both flags.

<sup>Written for commit 44724bacf1024ee34e9cf7ecceb1f788f201dd11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

