### PR TITLE
chore: add nuxt, nuxt-ui, chat-sdk, ai-sdk plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,11 @@
     "tsdown@pleaseai": true,
     "typescript-lsp@code-intelligence": true,
     "vitest@pleaseai": true,
-    "worktree@passionfactory": true
+    "worktree@passionfactory": true,
+    "nuxt@pleaseai": true,
+    "nuxt-ui@pleaseai": true,
+    "chat-sdk@pleaseai": true,
+    "ai-sdk@pleaseai": true
   },
   "extraKnownMarketplaces": {
     "passionfactory": {


### PR DESCRIPTION
## Summary

- Added 4 new plugins to `enabledPlugins` in `.claude/settings.json`:
  - `nuxt@pleaseai`
  - `nuxt-ui@pleaseai`
  - `chat-sdk@pleaseai`
  - `ai-sdk@pleaseai`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled `nuxt@pleaseai`, `nuxt-ui@pleaseai`, `chat-sdk@pleaseai`, and `ai-sdk@pleaseai` in `.claude/settings.json`. This turns on Nuxt and PleaseAI SDK tooling for the workspace.

<sup>Written for commit f51a913cf250cb8a587c05b629906941e0370abd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

