### PR TITLE
chore: add mastra plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,8 @@
     "nuxt@pleaseai": true,
     "nuxt-ui@pleaseai": true,
     "chat-sdk@pleaseai": true,
-    "ai-sdk@pleaseai": true
+    "ai-sdk@pleaseai": true,
+    "mastra@pleaseai": true
   },
   "extraKnownMarketplaces": {
     "passionfactory": {


### PR DESCRIPTION
## Summary
- Add `mastra@pleaseai` plugin to `.claude/settings.json` enabled plugins list

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `mastra@pleaseai` plugin to the enabled plugins in `.claude/settings.json` so it’s available in the development environment.

<sup>Written for commit bc2292425c5e6fbe351aa19b2a942fe2889a625f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

