### PR TITLE
refactor: rename @pleaseai/core to @pleaseai/work-core

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       app_release_created: ${{ steps.release.outputs['apps/work-please--release_created'] }}
+      core_release_created: ${{ steps.release.outputs['packages/core--release_created'] }}
     steps:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
@@ -30,7 +31,7 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish:
+  publish-app:
     needs: release-please
     if: ${{ needs.release-please.outputs.app_release_created == 'true' }}
     runs-on: ubuntu-latest
@@ -65,3 +66,39 @@ jobs:
 
       - run: npm publish --provenance --access public
         working-directory: apps/work-please
+
+  publish-core:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.core_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+      - name: Copy root files into package directory
+        run: cp LICENSE README.md packages/core/
+
+      - run: npm publish --provenance --access public
+        working-directory: packages/core

--- a/.please/docs/knowledge/tech-stack.md
+++ b/.please/docs/knowledge/tech-stack.md
@@ -68,7 +68,7 @@ work-please/                      # Monorepo root
 │   ├── app/                      # Client-side (pages, components, composables)
 │   ├── server/                   # Server-side (Nitro routes, plugins)
 │   └── src/                      # CLI entry point (Commander.js)
-├── packages/core/                # @pleaseai/core (orchestrator business logic)
+├── packages/core/                # @pleaseai/work-core (orchestrator business logic)
 └── vendor/symphony/              # Upstream reference spec (read-only)
 ```
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "apps/work-please": "0.1.13",
+  "packages/core": "0.1.0",
   ".": "0.1.0"
 }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,7 @@ work-please/                      # Monorepo root (Bun + Turborepo)
 │   │   │   └── webhooks/github.post.ts # POST /api/webhooks/github
 │   │   └── utils/orchestrator.ts # useOrchestrator() helper
 │   └── nuxt.config.ts            # Nuxt config (Bun preset, Nuxt UI)
-├── packages/core/                # @pleaseai/core — orchestrator business logic
+├── packages/core/                # @pleaseai/work-core — orchestrator business logic
 │   └── src/
 │       ├── orchestrator.ts       # Core loop: poll → reconcile → dispatch → retry
 │       ├── config.ts             # YAML front matter → typed ServiceConfig

--- a/apps/work-please/package.json
+++ b/apps/work-please/package.json
@@ -34,7 +34,7 @@
     "@chat-adapter/state-memory": "^4.20.2",
     "@nuxt/ui": "^4.5.1",
     "@octokit/graphql": "^9.0.3",
-    "@pleaseai/core": "workspace:*",
+    "@pleaseai/work-core": "workspace:*",
     "@vueuse/nuxt": "^14.2.1",
     "chat": "^4.20.2",
     "commander": "^14.0.3",

--- a/apps/work-please/server/api/v1/[identifier].get.ts
+++ b/apps/work-please/server/api/v1/[identifier].get.ts
@@ -1,5 +1,5 @@
-import type { OrchestratorState, RetryEntry, RunningEntry } from '@pleaseai/core'
-import { workspacePath } from '@pleaseai/core'
+import type { OrchestratorState, RetryEntry, RunningEntry } from '@pleaseai/work-core'
+import { workspacePath } from '@pleaseai/work-core'
 
 export default defineEventHandler((event) => {
   const orchestrator = useOrchestrator(event)

--- a/apps/work-please/server/api/v1/state.get.ts
+++ b/apps/work-please/server/api/v1/state.get.ts
@@ -1,4 +1,4 @@
-import type { OrchestratorState, RetryEntry, RunningEntry } from '@pleaseai/core'
+import type { OrchestratorState, RetryEntry, RunningEntry } from '@pleaseai/work-core'
 
 export default defineEventHandler((event) => {
   const orchestrator = useOrchestrator(event)

--- a/apps/work-please/server/api/webhooks/github.post.ts
+++ b/apps/work-please/server/api/webhooks/github.post.ts
@@ -1,6 +1,6 @@
-import type { VerifySignature } from '@pleaseai/core'
+import type { VerifySignature } from '@pleaseai/work-core'
 import type { Chat } from 'chat'
-import { createLogger, createVerify, handleWebhook } from '@pleaseai/core'
+import { createLogger, createVerify, handleWebhook } from '@pleaseai/work-core'
 
 const log = createLogger('webhook')
 

--- a/apps/work-please/server/plugins/01.orchestrator.ts
+++ b/apps/work-please/server/plugins/01.orchestrator.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { createLogger, Orchestrator } from '@pleaseai/core'
+import { createLogger, Orchestrator } from '@pleaseai/work-core'
 
 const log = createLogger('orchestrator')
 

--- a/apps/work-please/server/plugins/02.chat-bot.ts
+++ b/apps/work-please/server/plugins/02.chat-bot.ts
@@ -1,8 +1,8 @@
-import type { Orchestrator } from '@pleaseai/core'
+import type { Orchestrator } from '@pleaseai/work-core'
 import process from 'node:process'
 import { createGitHubAdapter } from '@chat-adapter/github'
 import { createMemoryState } from '@chat-adapter/state-memory'
-import { createLogger } from '@pleaseai/core'
+import { createLogger } from '@pleaseai/work-core'
 import { Chat } from 'chat'
 
 const log = createLogger('chat-bot')

--- a/apps/work-please/server/utils/orchestrator.ts
+++ b/apps/work-please/server/utils/orchestrator.ts
@@ -1,4 +1,4 @@
-import type { Orchestrator } from '@pleaseai/core'
+import type { Orchestrator } from '@pleaseai/work-core'
 import type { H3Event } from 'h3'
 
 export function useOrchestrator(_event: H3Event): Orchestrator {

--- a/apps/work-please/src/cli.ts
+++ b/apps/work-please/src/cli.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import process from 'node:process'
-import { setVerbose } from '@pleaseai/core'
+import { setVerbose } from '@pleaseai/work-core'
 import { Command, CommanderError } from 'commander'
 import pkg from '../package.json' with { type: 'json' }
 import { runInit } from './init'

--- a/apps/work-please/src/init.ts
+++ b/apps/work-please/src/init.ts
@@ -2,7 +2,7 @@ import { existsSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import { graphql as createGraphql, GraphqlResponseError } from '@octokit/graphql'
-import { createLogger } from '@pleaseai/core'
+import { createLogger } from '@pleaseai/work-core'
 
 const log = createLogger('work-please')
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/work-please": {
       "name": "@pleaseai/work",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "bin": {
         "work-please": "./dist/index.js",
       },
@@ -24,7 +24,7 @@
         "@chat-adapter/state-memory": "^4.20.2",
         "@nuxt/ui": "^4.5.1",
         "@octokit/graphql": "^9.0.3",
-        "@pleaseai/core": "workspace:*",
+        "@pleaseai/work-core": "workspace:*",
         "@vueuse/nuxt": "^14.2.1",
         "chat": "^4.20.2",
         "commander": "^14.0.3",
@@ -43,7 +43,7 @@
       },
     },
     "packages/core": {
-      "name": "@pleaseai/core",
+      "name": "@pleaseai/work-core",
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.72",
@@ -566,9 +566,9 @@
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
-    "@pleaseai/core": ["@pleaseai/core@workspace:packages/core"],
-
     "@pleaseai/work": ["@pleaseai/work@workspace:apps/work-please"],
+
+    "@pleaseai/work-core": ["@pleaseai/work-core@workspace:packages/core"],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,14 +1,25 @@
 {
-  "name": "@pleaseai/core",
+  "name": "@pleaseai/work-core",
   "type": "module",
   "version": "0.1.0",
   "description": "Core orchestrator logic for Work Please",
   "license": "FSL-1.1-MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pleaseai/work-please.git",
+    "directory": "packages/core"
+  },
   "exports": {
     ".": "./src/index.ts"
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "bun build ./src/index.ts --outdir ./dist --target bun",
     "check": "tsc --noEmit",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,12 @@
       "package-name": "@pleaseai/work",
       "changelog-path": "CHANGELOG.md",
       "initial-version": "0.1.0"
+    },
+    "packages/core": {
+      "release-type": "node",
+      "package-name": "@pleaseai/work-core",
+      "changelog-path": "CHANGELOG.md",
+      "initial-version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Rename `@pleaseai/core` → `@pleaseai/work-core` to align with the `@pleaseai/work` naming convention
- Add `packages/core` to release-please config and manifest for independent versioning
- Add `publish-core` CI job to publish the core package to npm on release
- Update all import references across the app

## Test plan

- [x] `bun run build` passes
- [x] `bun run check` passes (type-check)
- [x] No remaining `@pleaseai/core` references outside node_modules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `@pleaseai/core` to `@pleaseai/work-core` and set up independent releases and npm publishing for the core package. Updated all imports, docs, manifests, and CI to use the new name.

- **Migration**
  - Replace imports from `@pleaseai/core` to `@pleaseai/work-core`.
  - Update dependencies to `@pleaseai/work-core` in any `package.json` using the core package.

<sup>Written for commit a22e53b1e7aaf51505bfff629324c8836a9826d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

