### PR TITLE
chore: add review plugin configuration

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,5 @@
+{
+  "context": {
+    "fileName": ["CLAUDE.md", "GEMINI.md"]
+  }
+}

--- a/.please/config.yml
+++ b/.please/config.yml
@@ -9,3 +9,11 @@ docs:
   research: .please/docs/research
   references: .please/docs/references
   knowledge: .please/docs/knowledge
+
+review:
+  cubic:
+    enabled: true
+    default-flags: "--json -b"
+  gemini:
+    enabled: true
+    default-flags: "--sandbox"


### PR DESCRIPTION
## Summary

- Add `review:` section to `.please/config.yml` with cubic (`--json -b`) and Gemini (`--sandbox`) CLI settings
- Create `.gemini/settings.json` to configure Gemini CLI to read `CLAUDE.md` as project context

## Test plan

- [x] Verify `.please/config.yml` is valid YAML and contains correct review settings
- [x] Verify `.gemini/settings.json` is valid JSON
- [ ] Run `/review:run-cubic` to confirm cubic config is picked up
- [ ] Run `/review:run-gemini` to confirm Gemini config is picked up

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add review config for cubic and Gemini to standardize CLI flags and load shared context. Adds a `review` section to `.please/config.yml` (cubic `--json -b`, Gemini `--sandbox`) and `.gemini/settings.json` to read `CLAUDE.md` and `GEMINI.md`, so `/review:run-cubic` and `/review:run-gemini` pick up defaults.

<sup>Written for commit e9428c1f044ae4920d805f7ad23c21b39ddd63f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

