### PR TITLE
fix(ci): quote YAML step names containing colons

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Copy root files into package directory
         run: cp LICENSE README.md apps/work-please/
 
-      - name: Pack with bun (resolves workspace: protocol)
+      - name: 'Pack with bun (resolves workspace: protocol)'
         run: bun pm pack
         working-directory: apps/work-please
 
@@ -105,7 +105,7 @@ jobs:
       - name: Copy root files into package directory
         run: cp LICENSE README.md packages/core/
 
-      - name: Pack with bun (resolves workspace: protocol)
+      - name: 'Pack with bun (resolves workspace: protocol)'
         run: bun pm pack
         working-directory: packages/core
 


### PR DESCRIPTION
## Summary

- Quote step `name` values in `release-please.yml` that contain `workspace: protocol`
- YAML interprets `: ` (colon + space) as a key-value separator, causing workflow validation to fail
- Affects both `publish-app` and `publish-core` jobs

## Test plan

- [x] Verify workflow YAML passes GitHub Actions validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub Actions workflow validation by quoting step names that include "workspace: protocol" in `release-please.yml`. Prevents YAML from parsing colon+space as a key and unblocks the app and core publish jobs.

- **Bug Fixes**
  - Quoted the "Pack with bun (resolves workspace: protocol)" step in both publish jobs.

<sup>Written for commit 4828ed3e9a4eddc76cb63c7430357262ef39924b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

