### PR TITLE
feat(dashboard): add configurable vite allowed hosts

### DIFF
--- a/apps/work-please/nuxt.config.ts
+++ b/apps/work-please/nuxt.config.ts
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
       allowedHosts: (() => {
         const hosts = process.env.NUXT_VITE_ALLOWED_HOSTS
         if (!hosts)
-          return true
+          return []
         return hosts.split(',').map(h => h.trim()).filter(Boolean)
       })(),
     },


### PR DESCRIPTION
## Summary
- Add `NUXT_VITE_ALLOWED_HOSTS` environment variable to configure Vite dev server's `allowedHosts`
- Accepts comma-separated hostnames (e.g. `dora.passionfactory.ai,other.example.com`)
- Defaults to `true` (allow all hosts) when not set

## Test plan
- [ ] Set `NUXT_VITE_ALLOWED_HOSTS=dora.passionfactory.ai` and verify the host is allowed
- [ ] Run without the env var and verify all hosts are allowed (default)
- [ ] Set multiple comma-separated hosts and verify all are allowed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `NUXT_VITE_ALLOWED_HOSTS` to configure the `vite` dev server `allowedHosts` in `apps/work-please` (comma-separated, trimmed). Default is now empty (`[]`) to prevent DNS rebinding; also fixes ESLint in `nuxt.config.ts` by importing `process` from `node:process`.

- **Migration**
  - Set `NUXT_VITE_ALLOWED_HOSTS=dora.passionfactory.ai,other.example.com` to allow specific hosts.
  - Leave it unset to disallow external hosts (default).

<sup>Written for commit 822cc10731052da42399485a655e97a79c1d2b61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

