### PR TITLE
fix(ci): add --ignore-scripts to bun pm pack in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,7 +65,7 @@ jobs:
         run: cp LICENSE README.md apps/work-please/
 
       - name: 'Pack with bun (resolves workspace: protocol)'
-        run: bun pm pack
+        run: bun pm pack --ignore-scripts
         working-directory: apps/work-please
 
       - name: Publish tarball with npm (supports --provenance)
@@ -106,7 +106,7 @@ jobs:
         run: cp LICENSE README.md packages/core/
 
       - name: 'Pack with bun (resolves workspace: protocol)'
-        run: bun pm pack
+        run: bun pm pack --ignore-scripts
         working-directory: packages/core
 
       - name: Publish tarball with npm (supports --provenance)

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/work-please": {
       "name": "@pleaseai/work",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "bin": {
         "work-please": "./dist/index.js",
       },


### PR DESCRIPTION
## Summary

- Add `--ignore-scripts` flag to `bun pm pack` in the release-please publish workflow
- Prevents prepare/postinstall scripts from running during the pack step, which can cause publish failures
- Applied to both `apps/work-please` and `packages/core` publish jobs

## Test plan

- [ ] Verify release-please workflow YAML is valid
- [ ] Trigger a test release to confirm `bun pm pack --ignore-scripts` works correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--ignore-scripts` to `bun pm pack` in the release workflow. This prevents prepare/postinstall scripts from running during pack and avoids publish failures for `apps/work-please` and `packages/core`.

<sup>Written for commit a4f241389ba3f2d4487ad8d07bf50e0d998c1d5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

