### PR TITLE
ci: enable Turborepo remote cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ apps/agent-please/README.md
 .env.local
 WORKFLOW.local.md
 apps/agent-please/WORKFLOW.md
+# Turborepo
+.turbo


### PR DESCRIPTION
## Summary

- Add `TURBO_TOKEN` and `TURBO_TEAM` environment variables to the CI job so Turborepo can authenticate with the remote cache during GitHub Actions runs
- Add `.turbo` directory to `.gitignore` to exclude local Turborepo cache artifacts from version control

## Test plan

- [ ] Verify CI run uses Turborepo remote cache (check for cache hit/miss logs in Actions output)
- [ ] Confirm `.turbo` directory is no longer tracked by git

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `Turborepo` remote cache in CI to speed up builds and reduce redundant work. Injects `TURBO_TOKEN` and `TURBO_TEAM` into GitHub Actions and ignores the local `.turbo` cache directory.

- **Migration**
  - Set `TURBO_TOKEN` as a repo secret and `TURBO_TEAM` as a repo/org variable.

<sup>Written for commit 3484efd0d3825bdec9f66df4c4463f7208b78825. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

