### PR TITLE
ci: split CI into parallel jobs and add build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,13 @@ on:
 permissions:
   contents: read
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 jobs:
-  ci:
+  lint:
     runs-on: ubuntu-latest
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -37,11 +38,80 @@ jobs:
 
       - run: bun run lint
 
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - run: bun install --frozen-lockfile
+
       - run: bun run check
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - run: bun install --frozen-lockfile
 
       - run: bun run test:coverage
 
       - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        if: always()
         with:
           files: apps/agent-please/coverage/lcov.info
           flags: agent-please

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/agent-please": {
       "name": "@pleaseai/agent",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "bin": {
         "agent": "./dist/index.js",
         "agent-please": "./dist/index.js",
@@ -51,7 +51,7 @@
     },
     "packages/core": {
       "name": "@pleaseai/agent-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.72",
         "@chat-adapter/state-memory": ">=4.0.0",


### PR DESCRIPTION
## Summary

Splits the single sequential CI job into 4 parallel jobs, taking advantage of free parallel runners available on public repositories.

**New job structure:**
- `lint` - ESLint checks
- `check` - TypeScript type checking
- `build` - Verifies bundling succeeds (new)
- `test` - Runs the test suite (with `if: always()` on the codecov upload step so coverage is reported even when tests fail)

**Additional changes:**
- Moved `TURBO_TOKEN` and `TURBO_TEAM` env vars to workflow level so all jobs share the remote cache
- Added a dedicated `build` job to catch bundling regressions in CI
- `bun.lock` bumps are incidental from running `bun install`

## Why

Public repos get unlimited free parallel runners on GitHub Actions. Running lint, check, build, and test sequentially was wasting wall-clock time — this change makes CI feedback ~4x faster by running all four jobs concurrently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the CI pipeline into four parallel jobs and added a build step to catch bundling issues early. This makes feedback much faster by running lint, type checks, build, and tests at the same time.

- **Refactors**
  - Parallel jobs: `lint`, `check`, `build`, `test`.
  - Coverage upload in `test` uses `if: always()` so reports even if tests fail.
  - Moved `TURBO_TOKEN` and `TURBO_TEAM` to workflow `env` to share the remote cache across jobs.

- **Dependencies**
  - Incidental `bun.lock` bumps: `@pleaseai/agent` to `0.1.17`, `@pleaseai/agent-core` to `0.1.3`.

<sup>Written for commit c2c1d6e4a3cb3c6f98a1ac13e742eceb9c18f53d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

