### PR TITLE
fix(auth): use getMigrations API for auth database migrations

### DIFF
--- a/apps/agent-please/server/plugins/03.auth.ts
+++ b/apps/agent-please/server/plugins/03.auth.ts
@@ -1,6 +1,7 @@
 import type { Orchestrator } from '@pleaseai/agent-core'
 import { resolve } from 'node:path'
 import { createLogger } from '@pleaseai/agent-core'
+import { getMigrations } from 'better-auth/db/migration'
 
 const log = createLogger('auth')
 const MIN_ADMIN_PASSWORD_LENGTH = 8
@@ -22,7 +23,8 @@ export default defineNitroPlugin(async (nitroApp) => {
   const auth = initAuth(config.auth, dbPath)
 
   try {
-    await auth.api.runMigrations()
+    const { runMigrations } = await getMigrations(auth.options)
+    await runMigrations()
     log.info('auth migrations complete')
   }
   catch (err) {


### PR DESCRIPTION
## Summary

- Replace `auth.api.runMigrations()` with the correct `getMigrations` API from `better-auth/db/migration`
- `auth.api.runMigrations()` is not a function in the current version of better-auth
- The correct pattern is: `const { runMigrations } = await getMigrations(auth.options); await runMigrations()`

## Test Plan

- [ ] Verify server starts without errors on fresh database
- [ ] Confirm auth migrations are applied correctly on startup
- [ ] Verify existing auth tables are not affected on subsequent restarts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auth database migrations on startup by using `getMigrations(auth.options)` from `better-auth/db/migration` and calling the returned `runMigrations()`. Replaces the invalid `auth.api.runMigrations()` call to prevent startup errors and ensure migrations apply correctly.

<sup>Written for commit 1bb4c6708145aab1aac4a153590f593fd0e6acb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

