### PR TITLE
chore: add superset sandbox configuration

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,7 @@
+{
+  "setup": [
+    "(command -v mise >/dev/null || curl -fsSL https://mise.run | sh) && mise trust --yes && mise run setup"
+  ],
+  "teardown": [],
+  "run": []
+}


### PR DESCRIPTION
## Summary

- Add `.superset/config.json` with sandbox setup configuration using `mise`

## Changes

- New file: `.superset/config.json` — defines `setup`, `teardown`, and `run` lifecycle commands for the Superset sandbox environment

## Test Plan

- [ ] Verify sandbox setup runs correctly with `mise run setup`

## Related Issues

No linked issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.superset/config.json` to standardize the Superset sandbox lifecycle. The `setup` step auto-installs `mise` if missing, runs `mise trust --yes`, then executes `mise run setup`.

<sup>Written for commit 60069ca9bb2f15f7cb5ba99754c6e297b8c58bdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

