### PR TITLE
chore: add nuxt .nuxt/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ apps/agent-please/README.md
 .env.local
 WORKFLOW.local.md
 apps/agent-please/WORKFLOW.md
+# Nuxt
+.nuxt/
+
 # Turborepo
 .turbo


### PR DESCRIPTION
## Summary

- Adds `.nuxt/` to `.gitignore` to prevent Nuxt build artifacts from being tracked by git.

## Test Plan

- [ ] Verify `.nuxt/` directory is no longer tracked after a Nuxt build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.nuxt/` to `.gitignore` to prevent Nuxt build artifacts from being tracked, keeping the repo clean and avoiding accidental commits.

<sup>Written for commit 0099a083ae3cb08167a607d3d928d0e2b6d8eca2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

