### PR TITLE
chore: add testing-test-writer agent memory

### DIFF
--- a/.claude/agent-memory/testing-test-writer/MEMORY.md
+++ b/.claude/agent-memory/testing-test-writer/MEMORY.md
@@ -1,0 +1,4 @@
+# Test Writer Agent Memory
+
+## Project
+- [project_test_conventions.md](project_test_conventions.md) — bun:test patterns, Nitro polyfill strategy, better-auth SQLite migration pattern

--- a/.claude/agent-memory/testing-test-writer/project_test_conventions.md
+++ b/.claude/agent-memory/testing-test-writer/project_test_conventions.md
@@ -1,0 +1,29 @@
+---
+name: project test conventions
+description: Test framework, patterns, and conventions used in agent-please
+type: project
+---
+
+Test framework: bun:test (bun test runner)
+Import style: `import { describe, it, expect, afterEach, beforeEach, beforeAll, mock } from 'bun:test'`
+File placement: co-located next to source files (e.g. auth.ts -> auth.test.ts)
+Indentation: 2-space, single quotes, no semicolons (antfu eslint config)
+
+Nitro auto-imports (createError, etc.) are NOT available in test context.
+Must polyfill via `globalThis.createError = ...` in a `beforeAll` hook BEFORE importing the module under test.
+Use top-level `await import(...)` after the polyfill is registered.
+
+better-auth SQLite integration:
+- Use ':memory:' for in-memory SQLite (no file cleanup needed)
+- Must run migrations before using auth.api: `await (await (auth as any).$context).runMigrations()`
+- auth.$context is a Promise<AuthContext> — the context has runMigrations()
+
+Global mock pattern (no mock library): save and restore globalThis.fetch
+```
+const origFetch = globalThis.fetch
+globalThis.fetch = mock(async () => ...) as unknown as typeof fetch
+try { ... } finally { globalThis.fetch = origFetch }
+```
+
+**Why:** Codebase uses bun:test natively; no jest/vitest. Integration tests use real implementations, not heavy mock frameworks.
+**How to apply:** Always write co-located test files using bun:test imports. Polyfill Nitro globals before module imports.


### PR DESCRIPTION
## Summary
- Add agent memory for `testing:test-writer` with project test conventions and patterns learned from auth utils test generation

## Test plan
- [x] Memory files are valid markdown with correct frontmatter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent memory for the `testing-test-writer` to capture our test setup and patterns. This helps the test writer follow `bun:test` usage, `Nitro` polyfills, and `better-auth` SQLite migration steps.

- New Features
  - Added `.claude/agent-memory/testing-test-writer/` with `MEMORY.md` and `project_test_conventions.md`.
  - Documented co-located tests, `bun:test` imports, 2-space style.
  - Noted `Nitro` global polyfill-before-import pattern.
  - Described `better-auth` in-memory SQLite and migration flow.
  - Included safe global `fetch` mock pattern.
  - Markdown uses valid frontmatter.

<sup>Written for commit 5e19da0957fd535cee0b11f3c74d146936c246d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

