### PR TITLE
chore(claude): add safe permissions configuration to settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -127,7 +127,6 @@
       "Bash(gh run view:*)",
       "Bash(gh run list:*)",
       "Bash(gh auth status:*)",
-      "Bash(gh auth token:*)",
       "Bash(gh search:*)"
     ]
   },


### PR DESCRIPTION
## Summary

- Add 63 explicit allow rules to `.claude/settings.json` covering build tools (bun, bunx, turbo, tsc, eslint), read-only utilities (ls, cat, grep, find), safe git subcommands (status, log, diff, branch, checkout, add, commit), and read-only gh commands
- Destructive operations (rm, cp, mv, chmod, curl, git push, git reset, gh create) are intentionally excluded to require explicit user confirmation
- Includes a minor bun.lock version bump (0.1.17 → 0.1.18)

## Test Plan

- [ ] Verify that permitted commands (bun install, git status, etc.) execute without permission prompts
- [ ] Verify that excluded destructive commands (git push, rm, etc.) still require confirmation
- [ ] Confirm no regressions in existing build/test workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a strict command allowlist to `.claude/settings.json` so common build and read-only tasks run without prompts; destructive or high‑risk actions now require confirmation. Tightens permissions by removing `node:*`, `git rebase:*`, `gh api:*`, limiting `git config` to `--get/--list`, and allowing only `gh auth status` (drops `gh auth token`).

- **New Features**
  - Allow build tools: `bun`, `bunx`, `turbo`, `tsc`, `eslint`, `sg`.
  - Allow safe Unix and Git: `ls`, `echo`, `cat`, `grep`, `find`, `head`, `tail`, `pwd`, `mkdir`, `touch`, `which`, `xargs`, etc.; Git status/log/diff, branch/checkout/switch, add/commit, fetch/pull/stash/show/blame/tag, worktree/rev-parse/remote, merge/cherry-pick; read-only `git config`.
  - Allow read-only `gh`: `pr view/list/checks/diff`, `issue view/list`, `repo view`, `run view/list`, `auth status`, `search`.

<sup>Written for commit 253324394ad7b9ea873e6ab8575b93509b09355b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

