### PR TITLE
feat(tracker): include repository name in GitHub issue identifier

### DIFF
--- a/packages/core/src/tracker/github.ts
+++ b/packages/core/src/tracker/github.ts
@@ -57,6 +57,7 @@ export function createGitHubAdapter(project: ProjectConfig, platform: GitHubPlat
                 content {
                   ... on Issue {
                     number title body url
+                    repository { nameWithOwner }
                     labels(first: 20) { nodes { name } }
                     assignees(first: 10) { nodes { login } }
                     createdAt updatedAt
@@ -66,6 +67,7 @@ export function createGitHubAdapter(project: ProjectConfig, platform: GitHubPlat
                   }
                   ... on PullRequest {
                     number title body url
+                    repository { nameWithOwner }
                     labels(first: 20) { nodes { name } }
                     assignees(first: 10) { nodes { login } }
                     createdAt updatedAt
@@ -94,6 +96,7 @@ export function createGitHubAdapter(project: ProjectConfig, platform: GitHubPlat
                 content {
                   ... on Issue {
                     number title body url
+                    repository { nameWithOwner }
                     labels(first: 20) { nodes { name } }
                     assignees(first: 10) { nodes { login } }
                     createdAt updatedAt
@@ -103,6 +106,7 @@ export function createGitHubAdapter(project: ProjectConfig, platform: GitHubPlat
                   }
                   ... on PullRequest {
                     number title body url
+                    repository { nameWithOwner }
                     labels(first: 20) { nodes { name } }
                     assignees(first: 10) { nodes { login } }
                     createdAt updatedAt
@@ -137,6 +141,7 @@ export function createGitHubAdapter(project: ProjectConfig, platform: GitHubPlat
               content {
                 ... on Issue {
                   number title body url
+                  repository { nameWithOwner }
                   labels(first: 20) { nodes { name } }
                   assignees(first: 10) { nodes { login } }
                   createdAt updatedAt
@@ -146,6 +151,7 @@ export function createGitHubAdapter(project: ProjectConfig, platform: GitHubPlat
                 }
                 ... on PullRequest {
                   number title body url
+                  repository { nameWithOwner }
                   labels(first: 20) { nodes { name } }
                   assignees(first: 10) { nodes { login } }
                   createdAt updatedAt
@@ -174,9 +180,10 @@ export function createGitHubAdapter(project: ProjectConfig, platform: GitHubPlat
             }
           }
           content {
-            ... on Issue { number title }
+            ... on Issue { number title repository { nameWithOwner } }
             ... on PullRequest {
               number title headRefName reviewDecision
+              repository { nameWithOwner }
             }
           }
         }
@@ -386,7 +393,10 @@ function normalizeReviewDecision(raw: unknown): Issue['review_decision'] {
 function normalizeProjectItem(node: Record<string, unknown>, status: string, projectOwner?: string, projectNum?: number): Issue {
   const content = node.content as Record<string, unknown>
   const number = content?.number
-  const identifier = number ? `#${number}` : String(node.id ?? '')
+  const repo = (content?.repository as { nameWithOwner?: string })?.nameWithOwner
+  const identifier = number
+    ? (repo ? `${repo}#${number}` : `#${number}`)
+    : String(node.id ?? '')
   const labels = Array.isArray((content?.labels as { nodes?: Array<{ name?: string }> })?.nodes)
     ? ((content.labels as { nodes: Array<{ name?: string }> }).nodes).map(l => (l.name ?? '').toLowerCase()).filter(Boolean)
     : []

--- a/packages/core/src/tracker/tracker.test.ts
+++ b/packages/core/src/tracker/tracker.test.ts
@@ -234,7 +234,7 @@ describe('github_projects project_id path', () => {
               {
                 id: 'PVTI_1',
                 fieldValues: { nodes: [{ name: 'In Progress', field: { name: 'Status' } }] },
-                content: { number: 5, title: 'Node ID Issue', body: null, url: null, labels: { nodes: [] } },
+                content: { number: 5, title: 'Node ID Issue', body: null, url: null, labels: { nodes: [] }, repository: { nameWithOwner: 'myorg/myrepo' } },
               },
             ],
             pageInfo: { hasNextPage: false, endCursor: null },
@@ -250,9 +250,45 @@ describe('github_projects project_id path', () => {
         return
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe('PVTI_1')
-      expect(result[0].identifier).toBe('#5')
+      expect(result[0].identifier).toBe('myorg/myrepo#5')
       expect(result[0].title).toBe('Node ID Issue')
       expect(result[0].state).toBe('In Progress')
+    }
+    finally {
+      globalThis.fetch = origFetch
+    }
+  })
+
+  test('falls back to #number identifier when repository field is absent', async () => {
+    const project = makeGitHubProject({ project_id: 'PVT_kwABC123' })
+    const platform = makeGitHubPlatform()
+    const adapter = createGitHubAdapter(project, platform)
+
+    const origFetch = globalThis.fetch
+    globalThis.fetch = mock(async () => new Response(JSON.stringify({
+      data: {
+        node: {
+          items: {
+            nodes: [
+              {
+                id: 'PVTI_1',
+                fieldValues: { nodes: [{ name: 'In Progress', field: { name: 'Status' } }] },
+                content: { number: 7, title: 'No Repo Field', body: null, url: null, labels: { nodes: [] } },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch
+
+    try {
+      const result = await adapter.fetchIssuesByStates(['In Progress'])
+      expect(Array.isArray(result)).toBe(true)
+      if (!Array.isArray(result))
+        return
+      expect(result).toHaveLength(1)
+      expect(result[0].identifier).toBe('#7')
     }
     finally {
       globalThis.fetch = origFetch
@@ -471,7 +507,7 @@ describe('github_projects fetchIssueStatesByIds', () => {
                 { name: 'In Progress', field: { name: 'Status' } },
               ],
             },
-            content: { number: 42, title: 'Test Issue' },
+            content: { number: 42, title: 'Test Issue', repository: { nameWithOwner: 'myorg/myrepo' } },
           },
         ],
       },
@@ -484,7 +520,7 @@ describe('github_projects fetchIssueStatesByIds', () => {
         return
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe('PVTI_abc')
-      expect(result[0].identifier).toBe('#42')
+      expect(result[0].identifier).toBe('myorg/myrepo#42')
       expect(result[0].state).toBe('In Progress')
       expect(result[0].title).toBe('Test Issue')
     }
@@ -1011,7 +1047,7 @@ describe('github_projects pull_requests normalization', () => {
           {
             id: 'PVTI_abc',
             fieldValues: { nodes: [{ name: 'In Progress', field: { name: 'Status' } }] },
-            content: { number: 42, title: 'Test Issue' },
+            content: { number: 42, title: 'Test Issue', repository: { nameWithOwner: 'myorg/myrepo' } },
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Add `repository { nameWithOwner }` to all GitHub Projects v2 GraphQL queries
- Update `normalizeProjectItem` to build identifier as `org/repo#number` instead of `#number`
- Gracefully falls back to `#number` when repository field is absent

This makes identifiers unique across repositories in cross-repo GitHub Projects, improving dashboard readability and log debugging.

## Test plan
- [x] Updated existing tests to expect `myorg/myrepo#number` format
- [x] Added fallback test for missing repository field (`#number`)
- [x] All 716 tests pass (715 existing + 1 new)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `repository { nameWithOwner }` to all GitHub Projects v2 queries and formats issue/PR identifiers as `org/repo#number` instead of `#number`. Falls back to `#number` when the repository field is missing, making identifiers unique across repos while staying backward compatible and improving dashboard readability.

<sup>Written for commit 785b0086638841db1ec2a31e4c50aea5e8850b59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

