### PR TITLE
fix(cli): apply server.port from WORKFLOW.md to Nitro listen port

### DIFF
--- a/apps/agent-please/src/cli.ts
+++ b/apps/agent-please/src/cli.ts
@@ -49,12 +49,12 @@ export async function runCli(argv: string[]): Promise<void> {
     // Read server.port from WORKFLOW.md so Nitro binds to the configured port
     const wf = loadWorkflow(resolvedPath)
     if (!isWorkflowError(wf)) {
-      const server = wf.config.server
-      const serverPort = (server && typeof server === 'object' && !Array.isArray(server))
-        ? (server as Record<string, unknown>).port
-        : undefined
-      if (typeof serverPort === 'number' && Number.isInteger(serverPort) && serverPort >= 0) {
-        process.env.PORT = String(serverPort)
+      const serverConfig = wf.config.server
+      if (serverConfig && typeof serverConfig === 'object' && !Array.isArray(serverConfig)) {
+        const port = (serverConfig as Record<string, unknown>).port
+        if (typeof port === 'number' && Number.isInteger(port) && port >= 0) {
+          process.env.PORT = String(port)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- `server.port` in WORKFLOW.md was parsed but never used to set `process.env.PORT` before Nitro started, so the server always bound to port 3000
- The CLI now reads `server.port` from the workflow file before importing the Nitro server entry
- Port priority: `--port` flag > `PORT` env var > `server.port` in WORKFLOW.md > Nitro default (3000)

## Test plan
- [x] All 94 existing tests pass
- [x] Type-check passes
- [ ] Manual: set `server.port: 8080` in WORKFLOW.md, run `agent-please WORKFLOW.md`, verify server listens on 8080
- [ ] Manual: run `agent-please --port 9000 WORKFLOW.md` with `server.port: 8080`, verify 9000 wins
- [ ] Manual: run `PORT=7000 agent-please WORKFLOW.md` with `server.port: 8080`, verify 7000 wins

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the CLI so the server uses the port from WORKFLOW.md, with minor readability improvements in the CLI code. Sets PORT before Nitro starts so server.port is respected with this priority: --port flag > PORT env var > server.port in WORKFLOW.md > 3000.

<sup>Written for commit 908a7963816acbfd2434677c264394f23fa2fa98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

