### PR TITLE
ci(coverage): add JUnit test results reporting to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,6 @@ jobs:
       - uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
         if: ${{ !cancelled() }}
         with:
-          files: apps/agent-please/test-report.junit.xml
+          files: apps/agent-please/coverage/test-report.junit.xml
           flags: agent-please
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules/
 dist/
 .turbo/
 coverage/
-test-report.junit.xml
 *.tsbuildinfo
 .claude/settings.local.json
 .claude/worktrees/

--- a/apps/agent-please/package.json
+++ b/apps/agent-please/package.json
@@ -30,7 +30,7 @@
     "lint:fix": "eslint . --fix",
     "check": "tsc --noEmit",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage --reporter=default --reporter=junit --outputFile.junit=test-report.junit.xml"
+    "test:coverage": "vitest run --coverage --reporter=default --reporter=junit --outputFile.junit=coverage/test-report.junit.xml"
   },
   "dependencies": {
     "@chat-adapter/github": "^4.20.2",


### PR DESCRIPTION
## Summary

- Add JUnit XML test report output to the `test:coverage` vitest script
- Upload test results to Codecov via `codecov/test-results-action` in CI
- Ignore the generated `test-report.junit.xml` file in `.gitignore`
- Add `.nuxtrc` to pin the `@nuxt/test-utils` setup version (`4.0.0`)

## Test Plan

- [ ] Run `bun run test:coverage` locally and verify `test-report.junit.xml` is generated
- [ ] Verify CI pipeline uploads test results to Codecov successfully
- [ ] Confirm `test-report.junit.xml` is not tracked by git

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add JUnit test result reporting for `apps/agent-please` and upload results to Codecov. The JUnit report now lives under `coverage/` to keep the root clean and reuse existing ignore rules.

- **New Features**
  - `test:coverage` emits JUnit XML via `vitest` at `apps/agent-please/coverage/test-report.junit.xml`.
  - CI uploads JUnit results with `codecov/test-results-action`.

- **Dependencies**
  - Pinned `@nuxt/test-utils` setup to `4.0.0` in `.nuxtrc`.

<sup>Written for commit a4a8083a0666f68571dbf7743180787b4e5a5f53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

