### PR TITLE
chore(agent-please): add Codecov bundle analysis plugin

### DIFF
--- a/apps/agent-please/nuxt.config.ts
+++ b/apps/agent-please/nuxt.config.ts
@@ -7,7 +7,7 @@ export default defineNuxtConfig({
     '@vueuse/nuxt',
     '@nuxt/test-utils/module',
     ['@codecov/nuxt-plugin', {
-      enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+      enableBundleAnalysis: !!process.env.CODECOV_TOKEN,
       bundleName: 'agent-please',
       uploadToken: process.env.CODECOV_TOKEN,
     }],

--- a/apps/agent-please/package.json
+++ b/apps/agent-please/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "^7.7.0",
+    "@codecov/nuxt-plugin": "^1.9.1",
     "@iconify-json/lucide": "^1.2.98",
     "@nuxt/eslint": "^1.15.2",
     "@nuxt/test-utils": "^4.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,6 @@
       "name": "work-please",
       "devDependencies": {
         "@antfu/eslint-config": "^7.7.0",
-        "@codecov/nuxt-plugin": "^1.9.1",
-        "@pleaseai/agent": "^0.1.21",
         "eslint": "^10.0.3",
         "husky": "^9.1.7",
         "jiti": "^2.6.1",
@@ -43,6 +41,7 @@
       },
       "devDependencies": {
         "@antfu/eslint-config": "^7.7.0",
+        "@codecov/nuxt-plugin": "^1.9.1",
         "@iconify-json/lucide": "^1.2.98",
         "@nuxt/eslint": "^1.15.2",
         "@nuxt/test-utils": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.0",
   "devDependencies": {
     "@antfu/eslint-config": "^7.7.0",
-    "@codecov/nuxt-plugin": "^1.9.1",
-    "@pleaseai/agent": "workspace:*",
     "eslint": "^10.0.3",
     "husky": "^9.1.7",
     "jiti": "^2.6.1",


### PR DESCRIPTION
## Summary

- Add `@codecov/nuxt-plugin` as a dev dependency in the root `package.json`
- Configure the plugin in `apps/agent-please/nuxt.config.ts` as the last module entry
- Bundle analysis is conditionally enabled only when `CODECOV_TOKEN` env var is set
- `bundleName` is set to `'agent-please'`

## Test plan

- [ ] Verify the Nuxt app builds without errors (`bun run build`)
- [ ] Confirm bundle analysis is disabled when `CODECOV_TOKEN` is unset
- [ ] Confirm bundle analysis activates when `CODECOV_TOKEN` is set

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@codecov/nuxt-plugin` to the `agent-please` Nuxt app for conditional bundle analysis in CI; analysis runs only when a truthy `CODECOV_TOKEN` is set (used as `uploadToken`) and reports under the `agent-please` bundle name.
The plugin is now an app-level devDependency, and a stray root devDependency was removed.

<sup>Written for commit 4a48412d4baf88ce596c32e53df77760588df872. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

