### PR TITLE
fix(core): use bun:sqlite for local file database instead of native libsql

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/agent-please": {
       "name": "@pleaseai/agent",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "bin": {
         "agent": "./dist/index.js",
         "agent-please": "./dist/index.js",
@@ -64,7 +64,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
-        "docus": "latest",
+        "docus": "^5.8.1",
         "h3": "^1.15.8",
         "nuxt": "^4.4.2",
       },
@@ -75,7 +75,7 @@
     },
     "packages/core": {
       "name": "@pleaseai/agent-core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.72",
         "@chat-adapter/state-memory": ">=4.0.0",
@@ -86,6 +86,7 @@
         "consola": "^3.4.2",
         "js-yaml": "^4.1.1",
         "kysely": "^0.28.14",
+        "kysely-bun-sqlite": "^0.4.0",
         "liquidjs": "^10.25.0",
         "zod": "^4.3.6",
       },
@@ -2140,6 +2141,8 @@
     "knitwork": ["knitwork@1.3.0", "", {}, "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw=="],
 
     "kysely": ["kysely@0.28.14", "", {}, "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA=="],
+
+    "kysely-bun-sqlite": ["kysely-bun-sqlite@0.4.0", "", { "dependencies": { "bun-types": "^1.1.31" }, "peerDependencies": { "kysely": "^0.28.2" } }, "sha512-2EkQE5sT4ewiw7IWfJsAkpxJ/QPVKXKO5sRYI/xjjJIJlECuOdtG+ssYM0twZJySrdrmuildNPFYVreyu1EdZg=="],
 
     "launch-editor": ["launch-editor@2.13.1", "", { "dependencies": { "picocolors": "^1.1.1", "shell-quote": "^1.8.3" } }, "sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "consola": "^3.4.2",
     "js-yaml": "^4.1.1",
     "kysely": "^0.28.14",
+    "kysely-bun-sqlite": "^0.4.0",
     "liquidjs": "^10.25.0",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -3,7 +3,9 @@ import type { AgentRunRecord, AgentRunStatus, DbConfig } from './types'
 import { mkdirSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { LibsqlDialect } from '@libsql/kysely-libsql'
+import { Database } from 'bun:sqlite'
 import { Kysely, Migrator } from 'kysely'
+import { BunSqliteDialect } from 'kysely-bun-sqlite'
 import { createLogger } from './logger'
 import * as migration001 from './migrations/001_create_agent_runs'
 
@@ -62,9 +64,12 @@ export function createKyselyDb(config: DbConfig, workspaceRoot: string): Kysely<
   }
 
   try {
-    const dialect = new LibsqlDialect({ url: `file:${dbFilePath}` })
+    const dialect = new BunSqliteDialect({
+      database: new Database(dbFilePath, { create: true }),
+    })
+    const db = new Kysely<AppDatabase>({ dialect })
     log.info(`db opened: ${dbFilePath}`)
-    return new Kysely<AppDatabase>({ dialect })
+    return db
   }
   catch (err) {
     log.error(`db connection failed: ${err}`)


### PR DESCRIPTION
## Problem

When using a local file database path, the app used `LibsqlDialect` from `@libsql/kysely-libsql`, which relies on a native libsql NAPI binding. On certain platforms this binding throws:

```
TypeError: not enough arguments
```

This error originates deep in the native addon and is not recoverable at runtime.

## Solution

For local file database URLs (i.e. any URL that is not a remote Turso `libsql://` URL), switch to `BunSqliteDialect` from `kysely-bun-sqlite`, which uses Bun's built-in `bun:sqlite` module. This eliminates the dependency on the native NAPI binding for local-file usage entirely.

`LibsqlDialect` is retained for remote Turso URLs (`libsql://...`), so remote database connectivity is unchanged.

## Changes

- `packages/core/package.json` — added `kysely-bun-sqlite` as a dev dependency
- `packages/core/src/db.ts` — conditional dialect selection: `BunSqliteDialect` for local paths, `LibsqlDialect` for remote Turso URLs; moved "db opened" log after Kysely construction
- `bun.lock` — lockfile updated to include `kysely-bun-sqlite`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Bun’s `bun:sqlite` via `kysely-bun-sqlite` for local file databases to prevent native libsql crashes. Remote `libsql://` connections still use `@libsql/kysely-libsql`.

- **Bug Fixes**
  - Switch local file DB to `BunSqliteDialect` with `bun:sqlite`, fixing the “TypeError: not enough arguments” from the native libsql binding.
  - Move “db opened” log to after Kysely is constructed.

- **Dependencies**
  - Add `kysely-bun-sqlite` to `packages/core` dependencies.

<sup>Written for commit 96f18f15a9cf11d539b5dc43b8ba178934e952ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

