### PR TITLE
fix(orpc): change type-only import to value import in server plugin

### DIFF
--- a/apps/agent-please/app/plugins/orpc.server.ts
+++ b/apps/agent-please/app/plugins/orpc.server.ts
@@ -1,7 +1,7 @@
 import type { RouterClient } from '@orpc/server'
-import type { router } from '../../server/orpc'
 import { createRouterClient } from '@orpc/server'
 import { createTanstackQueryUtils } from '@orpc/tanstack-query'
+import { router } from '../../server/orpc'
 
 export default defineNuxtPlugin(() => {
   const client: RouterClient<typeof router> = createRouterClient(router, {

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/agent-please": {
       "name": "@pleaseai/agent",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "bin": {
         "agent": "./dist/index.js",
         "agent-please": "./dist/index.js",
@@ -80,7 +80,7 @@
     },
     "packages/core": {
       "name": "@pleaseai/agent-core",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.72",
         "@chat-adapter/state-memory": ">=4.0.0",


### PR DESCRIPTION
## Summary

- Changed `import type { router }` to `import { router }` in `apps/agent-please/app/plugins/orpc.server.ts`
- Type-only imports are erased at compile time and are not available at runtime

## Root Cause

`import type` is a TypeScript compile-time-only construct. When Nuxt/Vite builds the server plugin, the type import is stripped, leaving `router` undefined at runtime. This caused a 500 SSR error: "router is not defined".

## Test Plan

- [ ] Start dev server and verify SSR renders without 500 errors
- [ ] Verify oRPC routes respond correctly via TanStack Query client
- [ ] Check that no TypeScript errors are introduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SSR 500 errors ("router is not defined") by switching `router` to a value import in `apps/agent-please/app/plugins/orpc.server.ts` so it exists at runtime instead of being stripped during build.

<sup>Written for commit e5dce6eb944ef256a4f587692c305e2b79c01a29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

