### PR TITLE
docs: update ARCHITECTURE.md and add missing package READMEs

### DIFF
--- a/.claude/agent-memory/gardening-gardening-doc-gardener/MEMORY.md
+++ b/.claude/agent-memory/gardening-gardening-doc-gardener/MEMORY.md
@@ -1,0 +1,6 @@
+# Documentation Gardener Memory — agent-please
+
+## Project Structure Patterns
+
+- [project_structure.md](project_structure.md) — Monorepo layout, package names, known doc gaps
+- [recurring_issues.md](recurring_issues.md) — Issue types recurring across scans, chronic drift points

--- a/.claude/agent-memory/gardening-gardening-doc-gardener/project_structure.md
+++ b/.claude/agent-memory/gardening-gardening-doc-gardener/project_structure.md
@@ -1,0 +1,34 @@
+---
+name: project-structure
+description: Monorepo layout, package names, and structural conventions for doc gardening
+type: project
+---
+
+Monorepo root: agent-please (Bun + Turborepo)
+
+**Workspaces:**
+- `apps/agent-please` — Main Nuxt app (@pleaseai/agent), v0.1.x
+- `apps/docs` — Docus documentation site (@pleaseai/docs) — no README
+- `apps/relay-worker` — Cloudflare Worker (@pleaseai/relay-worker) — has README
+- `packages/core` — Orchestrator logic (@pleaseai/agent-core), v0.1.x — README created 2026-03-26
+- `packages/relay-client` — WebSocket relay client (@pleaseai/relay-client) — README created 2026-03-26
+- `packages/relay-server` — PartyServer relay server (@pleaseai/relay-server) — README created 2026-03-26
+
+**Documentation conventions:**
+- Root READMEs exist in 4 languages: en, ko, ja, zh-CN — keep synchronized
+- `.please/` is the project planning workspace (tracks, decisions, research, knowledge)
+- `.please/docs/tracks/index.md` must list all active tracks — orphaned tracks indicate gaps
+- `ARCHITECTURE.md` is the primary technical reference — track it carefully for drift
+- `SPEC.md` is the language-agnostic specification — rarely changes
+- Tech stack is documented in `.please/docs/knowledge/tech-stack.md` — kept up to date
+
+**API architecture (as of 2026-03-26):**
+- REST `/api/v1/*` routes were removed; replaced by oRPC at `/rpc/*` via `server/orpc/router.ts`
+- Webhooks remain as Nitro file routes: `/api/webhooks/{github,slack,asana}`
+- Auth routes via Better Auth: `/api/auth/[...all].ts`
+- New Nitro plugin: `03.auth.ts` (Better Auth initialization)
+
+**DB layer (as of 2026-03-26):**
+- Kysely replaces @libsql/client directly
+- Embedded: `bun:sqlite` + `kysely-bun-sqlite`
+- Cloud: Turso via `@libsql/kysely-libsql`

--- a/.claude/agent-memory/gardening-gardening-doc-gardener/recurring_issues.md
+++ b/.claude/agent-memory/gardening-gardening-doc-gardener/recurring_issues.md
@@ -1,0 +1,28 @@
+---
+name: recurring-doc-issues
+description: Chronic drift points and recurring issue types found in scans
+type: project
+---
+
+**Chronic drift: ARCHITECTURE.md**
+- This file drifts fastest because the codebase evolves rapidly (oRPC migration, relay packages, auth)
+- In the 2026-03-26 scan: 4 API route file paths were stale (v1/* Nitro routes replaced by oRPC)
+- New modules added to packages/core without updating ARCHITECTURE.md module listing
+- DB description said @libsql/client; actually Kysely since v0.1.8
+- 03.auth.ts plugin existed but was not listed in Entry Points or Module Structure
+
+**Structural gap: packages without READMEs**
+- packages/relay-client and packages/relay-server were created without READMEs (added 2026-03-26)
+- packages/core also lacked a README (added 2026-03-26)
+- apps/docs and apps/agent-please still lack READMEs (root README.md serves for agent-please)
+
+**Orphaned track plan:**
+- `.please/docs/tracks/active/dedup-dispatch-20260321/plan.md` exists but was not in tracks/index.md
+- This track has no formal spec file (conversation-derived)
+
+**Expected orphans (not real issues):**
+- .please/docs/tracks/active/*/plan.md and spec.md — accessed via tracks/index.md, link graph
+  misses them because .please/INDEX.md uses bare relative paths (not ./prefix)
+- .please/docs/research/md/* — accessed via research/index.md
+- apps/docs/content/* — Docus auto-discovers content, no explicit linking needed
+- CHANGELOG.md files — standalone, not meant to be linked

--- a/.claude/agent-memory/gardening-gardening-doc-gardener/state.json
+++ b/.claude/agent-memory/gardening-gardening-doc-gardener/state.json
@@ -1,4 +1,7 @@
 {
-  "last_scanned_commit": "42ffa7c6b3889fefa2ab3553709ef5311f6e3765",
-  "scanned_at": "2026-03-12T21:50:40+09:00"
+  "last_scan": {
+    "commit_hash": "bb55397",
+    "timestamp": "2026-03-26T00:00:00Z",
+    "scope": "."
+  }
 }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,13 +27,12 @@ runtime environment.
 | `apps/agent-please/src/cli.ts` | CLI argument parsing (`run`, `init`, `--port`) and Nuxt server startup |
 | `packages/core/src/orchestrator.ts` | Core poll/dispatch/retry loop — start reading here for runtime behavior |
 | `apps/agent-please/server/plugins/01.orchestrator.ts` | Nitro plugin: creates & starts the Orchestrator on server boot |
-| `apps/agent-please/server/api/v1/state.get.ts` | GET `/api/v1/state` — orchestrator state snapshot |
-| `apps/agent-please/server/api/v1/refresh.post.ts` | POST `/api/v1/refresh` — trigger immediate poll |
-| `apps/agent-please/server/api/v1/[identifier].get.ts` | GET `/api/v1/:identifier` — per-issue detail |
+| `apps/agent-please/server/plugins/02.chat-bot.ts` | Nitro plugin: Chat SDK bot (GitHub + Slack adapters) |
+| `apps/agent-please/server/plugins/03.auth.ts` | Nitro plugin: Better Auth initialization and admin bootstrap |
+| `apps/agent-please/server/orpc/router.ts` | oRPC router — all typed API procedures (state, refresh, issues, sessions, projects) |
 | `apps/agent-please/server/api/webhooks/github.post.ts` | POST `/api/webhooks/github` — GitHub webhook handler |
 | `apps/agent-please/server/api/webhooks/slack.post.ts` | POST `/api/webhooks/slack` — Slack webhook handler |
-| `apps/agent-please/server/api/v1/sessions/[sessionId]/messages.get.ts` | GET `/api/v1/sessions/:sessionId/messages` — session message history |
-| `apps/agent-please/server/plugins/02.chat-bot.ts` | Nitro plugin: Chat SDK bot (GitHub + Slack adapters) |
+| `apps/agent-please/server/api/webhooks/asana.post.ts` | POST `/api/webhooks/asana` — Asana webhook handler |
 | `WORKFLOW.md` | User-authored config file in the **target repository** (not this repo) — defines tracker settings, hooks, agent limits, and the Liquid prompt template |
 
 ## Module Structure
@@ -50,21 +49,28 @@ agent-please/                      # Monorepo root (Bun + Turborepo)
 │   │   ├── layouts/dashboard.vue # Nuxt UI Dashboard layout (sidebar + panels)
 │   │   ├── pages/
 │   │   │   ├── index.vue         # Dashboard: metrics, running/retry tables
-│   │   │   └── issues/[identifier].vue  # Issue detail: session, retry, events
+│   │   │   ├── issues/[identifier].vue  # Issue detail: session, retry, events
+│   │   │   ├── projects/         # Tracker project board view
+│   │   │   ├── sessions/         # Session message viewer
+│   │   │   └── login.vue         # Auth login page
 │   │   ├── components/           # StateBadge, RunningTable, RetryTable
-│   │   ├── composables/          # useOrchestratorState, useIssueDetail (useFetch-based)
+│   │   ├── composables/          # useOrchestratorState, useIssueDetail, useProjectBoard, useProjects, useSessionMessages
 │   │   └── utils/                # format.ts, types.ts
 │   ├── server/                   # Nitro server-side
 │   │   ├── plugins/
 │   │   │   ├── 01.orchestrator.ts # Nitro plugin: creates & starts Orchestrator
-│   │   │   └── 02.chat-bot.ts    # Nitro plugin: Chat SDK (GitHub + Slack adapters)
+│   │   │   ├── 02.chat-bot.ts    # Nitro plugin: Chat SDK (GitHub + Slack adapters)
+│   │   │   └── 03.auth.ts        # Nitro plugin: Better Auth initialization
+│   │   ├── orpc/
+│   │   │   ├── router.ts         # oRPC typed procedures (state, refresh, issues, sessions, projects)
+│   │   │   ├── middleware.ts     # oRPC middleware (auth)
+│   │   │   └── schemas.ts        # Zod schemas for oRPC
+│   │   ├── routes/rpc/           # Nitro route handler — mounts oRPC at /rpc/*
 │   │   ├── api/
-│   │   │   ├── v1/state.get.ts   # GET /api/v1/state
-│   │   │   ├── v1/refresh.post.ts # POST /api/v1/refresh
-│   │   │   ├── v1/[identifier].get.ts # GET /api/v1/:identifier
-│   │   │   ├── v1/sessions/[sessionId]/messages.get.ts # GET /api/v1/sessions/:sessionId/messages
+│   │   │   ├── auth/[...all].ts  # Better Auth handler
 │   │   │   ├── webhooks/github.post.ts # POST /api/webhooks/github
-│   │   │   └── webhooks/slack.post.ts  # POST /api/webhooks/slack
+│   │   │   ├── webhooks/slack.post.ts  # POST /api/webhooks/slack
+│   │   │   └── webhooks/asana.post.ts  # POST /api/webhooks/asana
 │   │   └── utils/orchestrator.ts # useOrchestrator() helper
 │   └── nuxt.config.ts            # Nuxt config (Bun preset, Nuxt UI)
 ├── packages/core/                # @pleaseai/agent-core — orchestrator business logic
@@ -79,13 +85,23 @@ agent-please/                      # Monorepo root (Bun + Turborepo)
 │       ├── label.ts              # GitHub label management
 │       ├── filter.ts             # Assignee and label filter matching
 │       ├── webhook.ts            # GitHub webhook verification + event filtering
-│       ├── db.ts                 # Agent run history storage (libsql/Turso)
+│       ├── dispatch-lock.ts      # Distributed dispatch lock (prevents duplicate agent dispatch)
+│       ├── issue-comment-handler.ts # GitHub issue comment @mention dispatch handler
+│       ├── relay-transport.ts    # WebSocket relay transport (cloud relay mode)
+│       ├── db.ts                 # Agent run history storage (Kysely — bun:sqlite or Turso)
+│       ├── db-types.ts           # Kysely database schema types
+│       ├── server.ts             # Standalone HTTP server (used without Nuxt)
+│       ├── state.ts              # Orchestrator state helpers
 │       ├── logger.ts             # Structured logging (consola withTag)
 │       ├── agent-env.ts          # Runtime env-var resolution for agent sessions
 │       ├── session-renderer.ts   # Session message extraction (claude-agent-sdk)
 │       ├── types.ts              # Shared type definitions
 │       ├── tracker/              # Issue tracker adapters (GitHub, Asana)
 │       └── index.ts              # Barrel export
+├── packages/relay-client/        # @pleaseai/relay-client — WebSocket relay client
+├── packages/relay-server/        # @pleaseai/relay-server — PartyServer relay server
+├── apps/relay-worker/             # @pleaseai/relay-worker — Cloudflare Worker deployment
+├── apps/docs/                    # @pleaseai/docs — Documentation site (Docus)
 ├── vendor/symphony/              # Upstream Symphony reference spec (read-only)
 ├── turbo.json                    # Turborepo task pipeline
 ├── eslint.config.ts              # @antfu/eslint-config
@@ -115,7 +131,7 @@ agent-please/                      # Monorepo root (Bun + Turborepo)
              │        │        │
      ┌───────▼──┐ ┌───▼───┐ ┌─▼──────────┐
      │ Tracker  │ │Workspace│ │ Agent      │
-     │ Client   │ │Manager │ │ Runner     │───▶ DB (libsql/Turso)
+     │ Client   │ │Manager │ │ Runner     │───▶ DB (Kysely/Turso)
      │(GitHub/  │ │(create,│ │(claude-    │    run history
      │ Asana)   │ │ hooks, │ │ agent-sdk) │
      └──────────┘ │worktree│ └────────────┘
@@ -275,10 +291,10 @@ usage). The bot lifecycle is managed by the Nitro plugin (startup/shutdown).
 
 ### Agent Run History
 
-`db.ts` provides persistent storage for agent run records using `@libsql/client`:
+`db.ts` provides persistent storage for agent run records using Kysely:
 
-- **Embedded mode** — Local SQLite file (default: `.agent-please/agent_runs.db`)
-- **Cloud mode** — Turso remote database via `db.turso_url` + `db.turso_auth_token` config
+- **Embedded mode** — Local SQLite file via `bun:sqlite` + `kysely-bun-sqlite` (default: `.agent-please/agent_runs.db`)
+- **Cloud mode** — Turso remote database via `@libsql/kysely-libsql` using `db.turso_url` + `db.turso_auth_token` config
 
 Records include issue identifier, session ID, duration, token usage, turn count, and status.
 The session messages API (`/api/v1/sessions/:sessionId/messages`) uses `session-renderer.ts` to

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,30 @@
+# @pleaseai/agent-core
+
+Core orchestrator logic for Agent Please.
+
+Contains all runtime business logic shared across deployment targets:
+
+- **Orchestrator** — poll/dispatch/retry/reconcile loop
+- **Config layer** — YAML front matter parsing, `$ENV_VAR` resolution
+- **Workflow loader** — `WORKFLOW.md` parser
+- **Issue tracker adapters** — GitHub Projects v2 (GraphQL) and Asana (REST)
+- **Workspace manager** — per-issue directory lifecycle, git worktrees, hooks
+- **Agent runner** — Claude Code session via `@anthropic-ai/claude-agent-sdk`
+- **DB layer** — agent run history via Kysely (bun:sqlite embedded or Turso cloud)
+- **Relay transport** — WebSocket relay client for cloud webhook delivery
+- **HTTP server** — standalone server for use without Nuxt
+
+See [ARCHITECTURE.md](../../ARCHITECTURE.md) for the full module structure.
+
+## Development
+
+```bash
+# Install dependencies (from project root)
+bun install
+
+# Test
+bun run --filter @pleaseai/agent-core test
+
+# Type check
+bun run --filter @pleaseai/agent-core check
+```

--- a/packages/relay-client/README.md
+++ b/packages/relay-client/README.md
@@ -1,0 +1,32 @@
+# @pleaseai/relay-client
+
+WebSocket relay client for Agent Please webhook events.
+
+Provides `RelayTransport` — an auto-reconnecting WebSocket client that connects Agent Please
+instances to a cloud relay worker (see `apps/relay-worker`) so they can receive webhook events
+without requiring a public inbound port.
+
+## Usage
+
+Configure in `WORKFLOW.md`:
+
+```yaml
+polling:
+  mode: relay
+
+relay:
+  url: agent-please-relay.<your-account>.workers.dev
+  room: my-project
+  token: $RELAY_AUTH_TOKEN
+  secret: $WEBHOOK_SECRET
+```
+
+## Development
+
+```bash
+# Install dependencies (from project root)
+bun install
+
+# Type check
+bun run --filter @pleaseai/relay-client check
+```

--- a/packages/relay-server/README.md
+++ b/packages/relay-server/README.md
@@ -1,0 +1,22 @@
+# @pleaseai/relay-server
+
+PartyServer relay server library for Agent Please webhook events.
+
+Provides `RelayParty` — a [PartyServer](https://github.com/partykit/partyserver) Durable Object
+class that receives webhook events, verifies signatures, and broadcasts lightweight envelopes to
+connected WebSocket clients.
+
+This package is used by `apps/relay-worker` (Cloudflare Worker deployment). It is not deployed
+directly.
+
+## Development
+
+```bash
+# Install dependencies (from project root)
+bun install
+
+# Type check
+bun run --filter @pleaseai/relay-server check
+```
+
+See [`apps/relay-worker/README.md`](../../apps/relay-worker/README.md) for deployment instructions.


### PR DESCRIPTION
## Summary

Documentation gardening sweep (--fix mode) fixing stale references after the oRPC migration and relay package split.

**Issues fixed:**
- (HIGH) Replace stale Nitro API route entry points with current oRPC routing references
- (HIGH) Update module structure section to reflect current package boundaries
- (HIGH) Correct DB library references that were removed during prior refactor
- (HIGH) Add missing `README.md` for `packages/relay-client`
- (MEDIUM) Add missing `README.md` for `packages/core` and `packages/relay-server`

## Changes

- `ARCHITECTURE.md` — updated entry points, module structure table, and DB library references to match current codebase state
- `packages/core/README.md` — new README for the core package
- `packages/relay-client/README.md` — new README for the relay-client package
- `packages/relay-server/README.md` — new README for the relay-server package
- `.claude/agent-memory/gardening-gardening-doc-gardener/` — updated scan state and agent memory files

## Test Plan

- [ ] Verify ARCHITECTURE.md entry points match actual source files
- [ ] Verify module structure table reflects current workspace layout
- [ ] Confirm DB library references are accurate
- [ ] Confirm all 3 new README files render correctly on GitHub

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated ARCHITECTURE.md to reflect the oRPC migration and relay split, and added missing READMEs for `@pleaseai/agent-core`, `@pleaseai/relay-client`, and `@pleaseai/relay-server`. Also corrected the DB docs to Kysely (embedded `bun:sqlite`, Turso via `@libsql/kysely-libsql`).

- **Documentation**
  - Replaced `/api/v1/*` references with oRPC `/rpc/*` via `server/orpc/router.ts` and noted auth middleware.
  - Added `03.auth.ts` (Better Auth) and webhook routes (GitHub, Slack, Asana) to entry points.
  - Updated module structure with new dashboard pages/composables and the relay packages.

<sup>Written for commit ad732ce2dfbf1e87785bacbebd1e5ae60d25564f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

