### PR TITLE
chore(release): add relay-client and relay-server to release-please config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,7 @@
 {
   "apps/agent-please": "0.1.26",
   "packages/core": "0.1.10",
+  "packages/relay-client": "0.1.0",
+  "packages/relay-server": "0.1.0",
   ".": "0.1.0"
 }

--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
     },
     "packages/core": {
       "name": "@pleaseai/agent-core",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.72",
         "@chat-adapter/state-memory": ">=4.0.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,18 @@
       "package-name": "@pleaseai/agent-core",
       "changelog-path": "CHANGELOG.md",
       "initial-version": "0.1.0"
+    },
+    "packages/relay-client": {
+      "release-type": "node",
+      "package-name": "@pleaseai/relay-client",
+      "changelog-path": "CHANGELOG.md",
+      "initial-version": "0.1.0"
+    },
+    "packages/relay-server": {
+      "release-type": "node",
+      "package-name": "@pleaseai/relay-server",
+      "changelog-path": "CHANGELOG.md",
+      "initial-version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Register `packages/relay-client` (`@pleaseai/relay-client`) with release-please
- Register `packages/relay-server` (`@pleaseai/relay-server`) with release-please
- Update `bun.lock` to reflect `@pleaseai/agent-core` bumped to `0.1.10`

## Test plan

- [ ] Verify release-please can parse the updated config without errors
- [ ] Confirm both new packages appear in future release PRs with version tracking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `packages/relay-client` (`@pleaseai/relay-client`) and `packages/relay-server` (`@pleaseai/relay-server`) to release-please for automated versioning and changelogs. Also sync `bun.lock` for `@pleaseai/agent-core` `0.1.10`.

- **Release config**
  - Register both packages in `release-please-config.json` with `initial-version` `0.1.0`.
  - Add both to `.release-please-manifest.json`.

- **Dependencies**
  - Update `bun.lock` to `@pleaseai/agent-core` `0.1.10`.

<sup>Written for commit 667dbdbff8447dc9971c5e9d4d09e6494bfed251. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

